### PR TITLE
[Fix] #16 Button 색상 수정 

### DIFF
--- a/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
+++ b/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 				Global/Resource/Font/.gitkeep,
 				Info.plist,
 				Network/Base/.gitkeep,
-				Presentation/Home/ViewModel/.gitkeep,
 				Presentation/MyPage/ViewModel/.gitkeep,
 				Presentation/Onboarding/ViewModel/.gitkeep,
 				Presentation/Walk/SharedWalk/ViewModel/.gitkeep,

--- a/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
@@ -7,13 +7,12 @@
 
 import SwiftUI
 
-struct SubmitButton: View {
+struct CTAButton: View {
     
     enum SubmitButtonStyle {
         case filled
         case outlined
         
-        // TODO: 디자인시스템 정해지면 색상 바꾸기
         func backgroundColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
@@ -67,6 +66,6 @@ struct SubmitButton: View {
 }
 
 #Preview {
-    SubmitButton(title: "버튼", isDisabled: false, buttonStyle: .filled)
+    CTAButton(title: "버튼", isDisabled: false, buttonStyle: .filled)
         .padding(.horizontal, 20)
 }

--- a/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
@@ -11,13 +11,13 @@ struct CTAButton: View {
     
     enum SubmitButtonStyle {
         case filled
-        case outlined
+        case text
         
         func backgroundColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
                 return isDisabled ? .gray200 : .beige500
-            case .outlined:
+            case .text:
                 return .clear
             }
         }
@@ -26,7 +26,7 @@ struct CTAButton: View {
             switch self {
             case .filled:
                 return  isDisabled ? .gray50 : .white
-            case .outlined:
+            case .text:
                 return isDisabled ? .gray200 : .beige500
             }
         }
@@ -35,7 +35,7 @@ struct CTAButton: View {
             switch self {
             case .filled:
                 return .clear
-            case .outlined:
+            case .text:
                 return .clear
             }
         }

--- a/PAWKEY/PAWKEY/Global/Component/Button/SubmitButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/SubmitButton.swift
@@ -17,7 +17,7 @@ struct SubmitButton: View {
         func backgroundColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
-                return isDisabled ? .gray : .green
+                return isDisabled ? .gray200 : .beige500
             case .outlined:
                 return .clear
             }
@@ -26,9 +26,9 @@ struct SubmitButton: View {
         func textColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
-                return .white
+                return  isDisabled ? .gray50 : .white
             case .outlined:
-                return isDisabled ? .gray : .green
+                return isDisabled ? .gray200 : .beige500
             }
         }
         
@@ -37,7 +37,7 @@ struct SubmitButton: View {
             case .filled:
                 return .clear
             case .outlined:
-                return isDisabled ? .gray : .green
+                return .clear
             }
         }
     }
@@ -67,6 +67,6 @@ struct SubmitButton: View {
 }
 
 #Preview {
-    SubmitButton(title: "버튼", isDisabled: false, buttonStyle: .filled)
+    SubmitButton(title: "버튼", isDisabled: false, buttonStyle: .outlined)
         .padding(.horizontal, 20)
 }

--- a/PAWKEY/PAWKEY/Global/Component/Button/SubmitButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/SubmitButton.swift
@@ -54,7 +54,7 @@ struct SubmitButton: View {
         } label: {
             Text(title)
                 .foregroundStyle(buttonStyle.textColor(isDisabled: isDisabled))
-                .font(.system(size: 16, weight: .semibold))
+                .font(.body_16_sb)
                 .frame(maxWidth: .infinity, maxHeight: 52.0)
         }
         .background(buttonStyle.backgroundColor(isDisabled: isDisabled))
@@ -67,6 +67,6 @@ struct SubmitButton: View {
 }
 
 #Preview {
-    SubmitButton(title: "버튼", isDisabled: false, buttonStyle: .outlined)
+    SubmitButton(title: "버튼", isDisabled: false, buttonStyle: .filled)
         .padding(.horizontal, 20)
 }

--- a/PAWKEY/PAWKEY/Global/Extension/Font+.swift
+++ b/PAWKEY/PAWKEY/Global/Extension/Font+.swift
@@ -37,4 +37,18 @@ extension Font {
         
         return .custom("\(familyName)-\(weightString)", size: size)
     }
+    
+    static let head_22_b = Font.pretendard(size: 22, weight: .bold)
+    static let head_22_sb = Font.pretendard(size: 22, weight: .semibold)
+    static let head_20_b = Font.pretendard(size: 20, weight: .bold)
+    static let head_20_sb = Font.pretendard(size: 20, weight: .semibold)
+    static let head_18_sb = Font.pretendard(size: 18, weight: .semibold)
+    static let body_16_sb = Font.pretendard(size: 16, weight: .semibold)
+    static let body_16_m = Font.pretendard(size: 16, weight: .semibold)
+    static let body_14_sb = Font.pretendard(size: 14, weight: .medium)
+    static let body_14_m = Font.pretendard(size: 14, weight: .medium)
+    static let body_14_r = Font.pretendard(size: 14, weight: .regular)
+    static let caption_12_sb = Font.pretendard(size: 12, weight: .semibold)
+    static let caption_12_m = Font.pretendard(size: 12, weight: .medium)
+    static let caption_12_r = Font.pretendard(size: 12, weight: .regular)
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #16
확정된 컬러로 Button 색상을 수정했습니다.
## 👷 작업한 내용
- Button 색상을 수정했어요
- ButtonStyle 이름을 변경했습니다.
- Typograph가 확정되어서 Font Extension에 추가해뒀습니다.

## ⌨️ 주요 코드 설명
`Font`: 설명
```swift
  static let head_22_b = Font.pretendard(size: 22, weight: .bold)
    static let head_22_sb = Font.pretendard(size: 22, weight: .semibold)
    static let head_20_b = Font.pretendard(size: 20, weight: .bold)
    static let head_20_sb = Font.pretendard(size: 20, weight: .semibold)
    static let head_18_sb = Font.pretendard(size: 18, weight: .semibold)
    static let body_16_sb = Font.pretendard(size: 16, weight: .semibold)
    static let body_16_m = Font.pretendard(size: 16, weight: .semibold)
    static let body_14_sb = Font.pretendard(size: 14, weight: .medium)
    static let body_14_m = Font.pretendard(size: 14, weight: .medium)
    static let body_14_r = Font.pretendard(size: 14, weight: .regular)
    static let caption_12_sb = Font.pretendard(size: 12, weight: .semibold)
    static let caption_12_m = Font.pretendard(size: 12, weight: .medium)
    static let caption_12_r = Font.pretendard(size: 12, weight: .regular)
}

사용예시
 Text(title)
      .font(.body_16_sb)
```

## ⚠️ 참고 사항
- 버튼이름이 애매하다고 생각했어서 CTAButton으로 네이밍을 수정했습니다.

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "" width ="200"> |

<img width="195" alt="스크린샷 2025-07-07 오후 9 12 00" src="https://github.com/user-attachments/assets/aa22589b-fd4b-4e8b-89f2-e1a738cdc588" />

