### PR TITLE
[Feat] #22 리뷰 차트뷰 컴포넌트 추가

### DIFF
--- a/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
+++ b/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
@@ -8,11 +8,29 @@
 import SwiftUI
 
 struct ReviewRatingBar: View {
+    let title: String
+    let rating: Double
     var body: some View {
-        Text("Hello, World!")
+        ZStack(alignment: .leading) {
+            GeometryReader { proxy in
+                RoundedRectangle(cornerRadius: 6)
+                    .frame(height: 37)
+                    .foregroundStyle(.pawkeyWhite2)
+                
+                RoundedRectangle(cornerRadius: 6)
+                    .frame(width: proxy.size.width * rating, height: 37)
+                    .foregroundStyle(.green)
+                Text(title)
+                    .font(.caption_12_sb)
+                    .frame(height: 37, alignment: .center)
+                    .padding(.leading, 13)
+            }
+            .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }
 
 #Preview {
-    ReviewRatingBar()
+    ReviewRatingBar(title: "후기 옵션 입력", rating: 0.8)
+        .padding(.horizontal, 20)
 }

--- a/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
+++ b/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
@@ -1,0 +1,18 @@
+//
+//  ReviewRatingBar.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/8/25.
+//
+
+import SwiftUI
+
+struct ReviewRatingBar: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+#Preview {
+    ReviewRatingBar()
+}

--- a/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
+++ b/PAWKEY/PAWKEY/Global/Component/ReviewRatingBar.swift
@@ -10,27 +10,43 @@ import SwiftUI
 struct ReviewRatingBar: View {
     let title: String
     let rating: Double
+    let rank: Int
+    
+    var progessBarColor: Color {
+        switch rank {
+        case 1:
+            return .green500
+        case 2:
+            return .green400
+        default:
+            return .green300
+        }
+    }
+    
     var body: some View {
-        ZStack(alignment: .leading) {
-            GeometryReader { proxy in
+        VStack {
+            ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 6)
                     .frame(height: 37)
                     .foregroundStyle(.pawkeyWhite2)
                 
-                RoundedRectangle(cornerRadius: 6)
-                    .frame(width: proxy.size.width * rating, height: 37)
-                    .foregroundStyle(.green)
+                GeometryReader { proxy in
+                    RoundedRectangle(cornerRadius: 6)
+                        .frame(width: proxy.size.width * rating, height: 37)
+                        .foregroundStyle(progessBarColor)
+                        .frame(height: 37)
+                }
                 Text(title)
                     .font(.caption_12_sb)
+                    .foregroundStyle(.pawkeyWhite1)
                     .frame(height: 37, alignment: .center)
                     .padding(.leading, 13)
             }
-            .fixedSize(horizontal: false, vertical: true)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 
 #Preview {
-    ReviewRatingBar(title: "후기 옵션 입력", rating: 0.8)
-        .padding(.horizontal, 20)
+    ReviewRatingBar(title: "후기 옵션 입력", rating: 0.8, rank: 1)
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #22 
## 👷 작업한 내용
- 차트뷰 컴포넌트를 추가했습니다.

## ⌨️ 주요 코드 설명
ZStack 으로 뷰를 중첩하는 방식으로 구현했어요
```swift
VStack {
            ZStack(alignment: .leading) {
                RoundedRectangle(cornerRadius: 6)
                    .frame(height: 37)
                    .foregroundStyle(.pawkeyWhite2)
                
                GeometryReader { proxy in
                    RoundedRectangle(cornerRadius: 6)
                        .frame(width: proxy.size.width * rating, height: 37)
                        .foregroundStyle(progessBarColor)
                        .frame(height: 37)
                }
                Text(title)
                    .font(.caption_12_sb)
                    .foregroundStyle(.pawkeyWhite1)
                    .frame(height: 37, alignment: .center)
                    .padding(.leading, 13)
            }
        }
        .fixedSize(horizontal: false, vertical: true)
```

## ⚠️ 참고 사항
- 순위에 따라서 색상을 변경하는 코드를 추가했어요

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "" width ="200"> |

<img src="https://github.com/user-attachments/assets/0b78ad38-5d97-4771-adc7-aff5288175d2"/>
