### PR TITLE
[Feat] #43 계정생성, 로그인 화면 구현

### DIFF
--- a/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
+++ b/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 @main
 struct PAWKEYApp: App {
+    @StateObject private var onboardingFlow = TabRouter<OnboardingScreen>()
+    
     var body: some Scene {
         WindowGroup {
-//            TabView()
-//                .onAppear {
-//                    LocationManager.shared.requestLocationPermission()
-//                }
-            OnboardingView()
+            RootView()
+                .environmentObject(onboardingFlow)
         }
     }
 }

--- a/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
+++ b/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
@@ -10,11 +10,13 @@ import SwiftUI
 @main
 struct PAWKEYApp: App {
     @StateObject private var onboardingFlow = TabRouter<OnboardingScreen>()
+    @StateObject private var tabBarState = TabBarState()
     
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(onboardingFlow)
+                .environmentObject(tabBarState)
         }
     }
 }

--- a/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
+++ b/PAWKEY/PAWKEY/Application/PAWKEYApp.swift
@@ -11,10 +11,11 @@ import SwiftUI
 struct PAWKEYApp: App {
     var body: some Scene {
         WindowGroup {
-            TabView()
-                .onAppear {
-                    LocationManager.shared.requestLocationPermission()
-                }
+//            TabView()
+//                .onAppear {
+//                    LocationManager.shared.requestLocationPermission()
+//                }
+            OnboardingView()
         }
     }
 }

--- a/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
@@ -16,7 +16,7 @@ struct CTAButton: View {
         func backgroundColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
-                return isDisabled ? .gray200 : .beige500
+                return isDisabled ? .gray200 : .green500
             case .text:
                 return .clear
             }
@@ -27,7 +27,7 @@ struct CTAButton: View {
             case .filled:
                 return  isDisabled ? .gray50 : .white
             case .text:
-                return isDisabled ? .gray200 : .beige500
+                return isDisabled ? .gray200 : .green500
             }
         }
         

--- a/PAWKEY/PAWKEY/Global/Extension/UIApplication+.swift
+++ b/PAWKEY/PAWKEY/Global/Extension/UIApplication+.swift
@@ -1,0 +1,20 @@
+//
+//  UIApplication+.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/9/25.
+//
+
+import SwiftUI
+
+extension UIApplication {
+    func hideKeyboard() {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first else {
+            return
+        }
+        let tapRecognizer = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
+        tapRecognizer.cancelsTouchesInView = false
+        window.addGestureRecognizer(tapRecognizer)
+    }
+}

--- a/PAWKEY/PAWKEY/Global/Router/OnboardingFlow.swift
+++ b/PAWKEY/PAWKEY/Global/Router/OnboardingFlow.swift
@@ -1,0 +1,29 @@
+//
+//  OnboardingFlow.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/9/25.
+//
+
+import SwiftUI
+
+struct OnboardingFlow: View {
+    @EnvironmentObject var router: TabRouter<OnboardingScreen>
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            OnboardingView()
+                .navigationDestination(for: OnboardingScreen.self) { screen in
+                    build(screen: screen)
+                }
+        }
+    }
+    
+    @ViewBuilder
+    private func build(screen: OnboardingScreen) -> some View {
+        switch screen {
+        case .login:
+            LoginView(isLoggedIn: .constant(false))
+        }
+    }
+}

--- a/PAWKEY/PAWKEY/Global/Router/ScreenEnum.swift
+++ b/PAWKEY/PAWKEY/Global/Router/ScreenEnum.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum HomeScreen: Hashable {
-    case home
+    case home    
     case changeMyArea
 }
 
@@ -29,4 +29,8 @@ enum MyPageScreen: Hashable {
     case myPage
     case userProfile
     case petProfile
+}
+
+enum OnboardingScreen: Hashable {
+    case login
 }

--- a/PAWKEY/PAWKEY/Global/Router/TabBarState.swift
+++ b/PAWKEY/PAWKEY/Global/Router/TabBarState.swift
@@ -10,4 +10,5 @@ import SwiftUI
 final class TabBarState: ObservableObject {
     @Published var selectedTab: TabBarItem = .home
     @Published var isHidden: Bool = false
+    @Published var isLogin: Bool = false
 }

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
@@ -29,7 +29,7 @@ struct RootView: View {
         if isLoggedIn {
             TabView()
         } else {
-            LoginView(isLoggedIn: $isLoggedIn)
+            OnboardingFlow()
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
@@ -9,22 +9,49 @@ import SwiftUI
 
 struct LoginView: View {
     @Binding var isLoggedIn: Bool
+    @State private var idText = ""
+    @State private var passwordText = ""
+    
+    var isDisabled: Bool {
+        idText.isEmpty || passwordText.isEmpty
+    }
     
     var body: some View {
         VStack {
-            Text("로그인 화면")
-                .font(.largeTitle)
-            
-            Button("로그인 성공") {
-                isLoggedIn = true
+            Spacer().frame(height: 120)
+            VStack(alignment: .leading) {
+                Text("아이디")
+                    .font(.body_14_sb)
+                PKTextField(text: $idText, placeholder: "아이디")
+                    .padding(.top, 10)
             }
+            
+            VStack(alignment: .leading) {
+                Text("비밀번호")
+                    .font(.body_14_sb)
+                PKTextField(text: $passwordText, placeholder: "사용하실 비밀번호를 입력해주세요.", type: .password)
+                    .padding(.top, 10)
+            }
+            .padding(.top, 37)
+            
+            Spacer()
+            
+            CTAButton(title: "신규 계정으로 회원가입", buttonStyle: .text)
+            CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled)
+                .padding(.top, 12)
+                .padding(.bottom, 60)
         }
+        .padding(.horizontal, 16)
+        .topNavigationView(center: {
+            Text("기존 계정으로 로그인")
+                .font(.body_16_sb)
+        })
     }
 }
 
 struct RootView: View {
     @State private var isLoggedIn = false
-
+    
     var body: some View {
         if isLoggedIn {
             TabView()

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
@@ -44,6 +44,10 @@ struct LoginView: View {
                 .padding(.bottom, 60)
         }
         .padding(.horizontal, 16)
+        .ignoresSafeArea(.keyboard)
+        .onTapGesture {
+            UIApplication.shared.hideKeyboard()
+        }
         .topNavigationView(center: {
             Text("기존 계정으로 로그인")
                 .font(.body_16_sb)

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/LoginView.swift
@@ -11,7 +11,7 @@ struct LoginView: View {
     @Binding var isLoggedIn: Bool
     @State private var idText = ""
     @State private var passwordText = ""
-    
+    @EnvironmentObject var tabBarState: TabBarState
     var isDisabled: Bool {
         idText.isEmpty || passwordText.isEmpty
     }
@@ -37,7 +37,9 @@ struct LoginView: View {
             Spacer()
             
             CTAButton(title: "신규 계정으로 회원가입", buttonStyle: .text)
-            CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled)
+            CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled) {
+                tabBarState.isLogin = true
+            }
                 .padding(.top, 12)
                 .padding(.bottom, 60)
         }
@@ -51,9 +53,9 @@ struct LoginView: View {
 
 struct RootView: View {
     @State private var isLoggedIn = false
-    
+    @EnvironmentObject var tabBarState: TabBarState
     var body: some View {
-        if isLoggedIn {
+        if tabBarState.isLogin {
             TabView()
         } else {
             OnboardingFlow()

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
@@ -9,6 +9,28 @@ import SwiftUI
 
 struct OnboardingView: View {
     var body: some View {
-        Text("온보딩")
+        VStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("안녕하세요.")
+                Text("우리 강아지를 위한 산책,")
+                HStack {
+                    Text("PAWKEY")
+                        .foregroundStyle(.green500)
+                    Text("와 함께해요!")
+                }
+            }
+            .font(.head_22_sb)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 50)
+            
+            Spacer()
+            
+            VStack(spacing: 20) {
+                CTAButton(title: "신규계정으로 회원가입")
+                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text)
+            }
+            .padding(.bottom, 47)
+        }
+        .padding(.horizontal, 16)
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
-    @EnvironmentObject var router: TabRouter<HomeScreen>
+    @EnvironmentObject var router: TabRouter<OnboardingScreen>
     
     var body: some View {
         VStack {
@@ -29,8 +29,8 @@ struct OnboardingView: View {
             
             VStack(spacing: 20) {
                 CTAButton(title: "신규계정으로 회원가입")
-                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text) {
-                    
+                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text) {                    
+                    router.push(.login)
                 }
             }
             .padding(.bottom, 47)

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OnboardingView: View {
+    @EnvironmentObject var router: TabRouter<HomeScreen>
+    
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 2) {
@@ -27,7 +29,9 @@ struct OnboardingView: View {
             
             VStack(spacing: 20) {
                 CTAButton(title: "신규계정으로 회원가입")
-                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text)
+                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text) {
+                    
+                }
             }
             .padding(.bottom, 47)
         }

--- a/PAWKEY/PAWKEY/Presentation/TabView.swift
+++ b/PAWKEY/PAWKEY/Presentation/TabView.swift
@@ -12,7 +12,7 @@ struct TabView: View {
     @StateObject private var walkRouter = TabRouter<WalkScreen>()
     @StateObject private var myPageRouter = TabRouter<MyPageScreen>()
     
-    @StateObject private var tabBarState = TabBarState()
+    @EnvironmentObject var tabBarState: TabBarState
     
     var body: some View {
         ZStack {
@@ -20,24 +20,20 @@ struct TabView: View {
             case .home:
                 HomeFlow()
                     .environmentObject(homeRouter)
-                    .environmentObject(tabBarState)
             case .walk:
                 WalkFlow()
                     .environmentObject(walkRouter)
-                    .environmentObject(tabBarState)
             case .community:
                 CommunityView()
             case .mypage:
                 MyPageFlow()
                     .environmentObject(myPageRouter)
-                    .environmentObject(tabBarState)
             }
             
             VStack {
                 Spacer()
                 
                 TabBarView()
-                    .environmentObject(tabBarState)
             }
         }
     }

--- a/PAWKEY/PAWKEY/Presentation/Walk/Walk/View/WalkCompletionView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/Walk/View/WalkCompletionView.swift
@@ -66,7 +66,7 @@ struct WalkCompletionView: View {
             
             Spacer()
             
-            SubmitButton(
+            CTAButton(
                 title: "기록하러가기",
                 isDisabled: false,
                 buttonStyle: .filled

--- a/PAWKEY/PAWKEY/Presentation/Walk/Walk/View/WalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/Walk/View/WalkCourseView.swift
@@ -72,7 +72,7 @@ struct WalkCourseView: View {
                 } else {
                     Spacer()
                     
-                    SubmitButton(
+                    CTAButton(
                         title: "종료하기",
                         isDisabled: false,
                         buttonStyle: .filled


### PR DESCRIPTION
## 📟 연결된 이슈
closed #43 

## 👷 작업한 내용
- 계정 생성 화면 구현
- 로그인 화면 구현
- 로그인 상태에 따라서 화면 분기 처리
- OnboardingFlow 추가

## ⌨️ 주요 코드 설명
`LoginView`: 설명
```swift
Code
```

## ⚠️ 참고 사항
- 계정생성 화면이 비어있는데 추후에 이미지가 추가될 것 같습니다.
- 계정생성 화면 작업양이 애매해서 로그인 화면까지 같이 처리했어요

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/1480e5aa-85f0-4f57-a91a-21c2158ebad8" width ="200"> | <img src = "https://github.com/user-attachments/assets/bbb3b320-428b-4e91-815c-f064ccf0fb1d" width ="200"> | <img src = "https://github.com/user-attachments/assets/101293cf-a76d-4b23-a7ee-ba965db9a19f" width ="200"> |

