### PR TITLE
[Fix] #58 로그인 화면 밀림 현상

### DIFF
--- a/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Button/CTAButton.swift
@@ -12,12 +12,15 @@ struct CTAButton: View {
     enum SubmitButtonStyle {
         case filled
         case text
+        case borderless
         
         func backgroundColor(isDisabled: Bool) -> Color {
             switch self {
             case .filled:
                 return isDisabled ? .gray200 : .green500
             case .text:
+                return .clear
+            case .borderless:
                 return .clear
             }
         }
@@ -28,6 +31,9 @@ struct CTAButton: View {
                 return  isDisabled ? .gray50 : .pawkeyWhite1
             case .text:
                 return isDisabled ? .gray200 : .green500
+            case .borderless:
+                return .green500
+                
             }
         }
         
@@ -37,6 +43,9 @@ struct CTAButton: View {
                 return .clear
             case .text:
                 return isDisabled ? .gray200 : .green500
+            case .borderless:
+                return .clear
+                
             }
         }
     }

--- a/PAWKEY/PAWKEY/Global/Component/TextField/PKTextField.swift
+++ b/PAWKEY/PAWKEY/Global/Component/TextField/PKTextField.swift
@@ -33,7 +33,7 @@ struct PKTextField: View {
             case .password:
                 HStack {
                     ZStack {
-                                .focused($isFocused)
+                        SecureField(placeholder ?? "입력해주세요", text: $text)
                             .opacity(isShowPassword ? 0 : 1)
                             .focused($isFocused)
                             .font(.body_14_r)

--- a/PAWKEY/PAWKEY/Global/Component/TextField/PKTextField.swift
+++ b/PAWKEY/PAWKEY/Global/Component/TextField/PKTextField.swift
@@ -15,7 +15,7 @@ struct PKTextField: View {
         case number
     }
     
-    @State var isShowPassword = false
+    @State private var isShowPassword = false
     @Binding var text: String
     @FocusState private var isFocused: Bool
     
@@ -23,52 +23,46 @@ struct PKTextField: View {
     var type: TextFieldType = .normal
     
     var body: some View {
-        ZStack {
-            VStack {
-                switch type {
-                case .normal:
-                    TextField(text: $text) {
-                        Text(placeholder ?? "입력해주세요")
-                            .font(.body_14_r)
-                            .foregroundStyle(.gray200)
-                    }
+        Group {
+            switch type {
+            case .normal:
+                TextField(placeholder ?? "입력해주세요", text: $text)
                     .focused($isFocused)
-                case .password:
-                    HStack {
-                        ZStack {
-                            SecureField("", text: $text)
-                                .opacity(isShowPassword ? 0 : 1)
+                    .font(.body_14_r)
+                
+            case .password:
+                HStack {
+                    ZStack {
                                 .focused($isFocused)
-                                .font(.body_14_r)
-                            
-                            TextField(placeholder ?? "입력해주세요", text: $text)
-                                .opacity(isShowPassword ? 1 : 0)
-                                .focused($isFocused)
-                                .font(.body_14_r)
-                        }
+                            .opacity(isShowPassword ? 0 : 1)
+                            .focused($isFocused)
+                            .font(.body_14_r)
                         
-                        Button {
-                            isShowPassword.toggle()
-                        } label: {
-                            Image(isShowPassword ? .eyeGray : .eyeSlashGray)
-                                .padding(.trailing, 16)
-                        }
-                    }
-                case .number:
-                    TextField(text: $text) {
-                        Text(placeholder ?? "입력해주세요")
+                        TextField(placeholder ?? "입력해주세요", text: $text)
+                            .opacity(isShowPassword ? 1 : 0)
+                            .focused($isFocused)
                             .font(.body_14_r)
-                            .foregroundStyle(.gray200)
                     }
-                    .focused($isFocused)
-                    .keyboardType(.numberPad)
+                    
+                    Button {
+                        isShowPassword.toggle()
+                    } label: {
+                        Image(isShowPassword ? .eyeGray : .eyeSlashGray)
+                            .padding(.trailing, 16)
+                    }
                 }
+                
+            case .number:
+                TextField(placeholder ?? "입력해주세요", text: $text)
+                    .keyboardType(.numberPad)
+                    .focused($isFocused)
+                    .font(.body_14_r)
             }
-            .padding(.leading, 16)
         }
-        .frame(height: 52.0)
+        .padding(.leading, 16)
+        .frame(height: 52)
         .overlay(
-            RoundedRectangle(cornerRadius: 8.0)
+            RoundedRectangle(cornerRadius: 8)
                 .stroke(lineWidth: 1)
                 .foregroundStyle(isFocused ? .black : .gray200)
         )
@@ -76,6 +70,6 @@ struct PKTextField: View {
 }
 
 #Preview {
-    PKTextField(text: .constant(""), placeholder: "비번입력", type: .password)
+    PKTextField(text: .constant(""), placeholder: "비밀번호 입력", type: .password)
         .padding(.horizontal, 20)
 }

--- a/PAWKEY/PAWKEY/Presentation/Login/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Login/LoginView.swift
@@ -21,35 +21,36 @@ struct LoginView: View {
     }
     
     var body: some View {
-        VStack {
-            Spacer().frame(height: 120)
-            VStack(alignment: .leading) {
-                Text("아이디")
-                    .font(.body_14_sb)
-                PKTextField(text: $idText, placeholder: "아이디")
-                    .padding(.top, 10)
-            }
-            
-            VStack(alignment: .leading) {
-                Text("비밀번호")
-                    .font(.body_14_sb)
-                PKTextField(text: $passwordText, placeholder: "사용하실 비밀번호를 입력해주세요.", type: .password)
-                    .padding(.top, 10)
-            }
-            .padding(.top, 37)
-            
-            Spacer()
-            
+        ScrollView(showsIndicators: false) {
+            VStack {
+                VStack(alignment: .leading) {
+                    Text("아이디")
+                        .font(.body_14_sb)
+                    PKTextField(text: $idText, placeholder: "아이디")
+                        .padding(.top, 10)
+                }
+                .padding(.top, 123)
+                
+                VStack(alignment: .leading) {
+                    Text("비밀번호")
+                        .font(.body_14_sb)
+                    PKTextField(text: $passwordText, placeholder: "사용하실 비밀번호를 입력해주세요.", type: .password)
+                        .padding(.top, 10)
+                }
+                .padding(.top, 37)
+                .padding(.bottom, 154)
+                
             CTAButton(title: "신규 계정으로 회원가입", buttonStyle: .text) {
-                router.push(.profileSetUp)
-            }
-            CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled) {
-                tabBarState.isLogin = true
-            }
+                    router.push(.profileSetUp)
+                }
+                CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled) {
+                    tabBarState.isLogin = true
+                }
                 .padding(.top, 12)
                 .padding(.bottom, 60)
+            }
+            .padding(.horizontal, 16)
         }
-        .padding(.horizontal, 16)
         .ignoresSafeArea(.keyboard)
         .onTapGesture {
             UIApplication.shared.hideKeyboard()

--- a/PAWKEY/PAWKEY/Presentation/Login/LoginView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Login/LoginView.swift
@@ -40,7 +40,7 @@ struct LoginView: View {
                 .padding(.top, 37)
                 .padding(.bottom, 154)
                 
-            CTAButton(title: "신규 계정으로 회원가입", buttonStyle: .text) {
+                CTAButton(title: "신규 계정으로 회원가입", buttonStyle: .borderless) {
                     router.push(.profileSetUp)
                 }
                 CTAButton(title: "로그인", isDisabled: isDisabled, buttonStyle: .filled) {

--- a/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Onboarding/View/OnboardingView.swift
@@ -29,7 +29,7 @@ struct OnboardingView: View {
             
             VStack(spacing: 20) {
                 CTAButton(title: "신규계정으로 회원가입")
-                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .text) {                    
+                CTAButton(title: "기존 계정으로 로그인", buttonStyle: .borderless) {                    
                     router.push(.login)
                 }
             }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #58 

## 👷 작업한 내용
- ScrollView 추가로 화면 밀림 현상 해결 (텍스트필드가 있는 다른 화면과 코드 비교했을 때 ScrollView 차이가 있어서 추가했더니 밀림 현상이 사라졌습니다)
- 불필요하게 중첩되어있는 ZStack과 VStack 제거 (텍스트필드 여러 번 클릭해도 포커스되는 게 살짝 느렸는데 혹시 개선이 됐을 수도 있어요)
- password placeholder 안 보이는 현상 해결
- border 없는 텍스트 버튼 스타일 추가 및 적용

## ⌨️ 주요 코드 설명
`CTAButton`: borderless 정의하고 borderColor를 .clear 속성을 주었습니다.
```swift
func borderColor(isDisabled: Bool) -> Color {
            switch self {
            case .filled:
                return .clear
            case .text:
                return isDisabled ? .gray200 : .green500
            case .borderless:
                return .clear
                
            }
        }
```

`PKTextField`: SecureField에 placeholder 추가했습니다.
```swift
SecureField(placeholder ?? "입력해주세요", text: $text)
```

## ⚠️ 참고 사항
- 간격은 피그마랑 똑같이 했는데 se가 화면이 작아서 그런지 레이아웃 개선이 필요할 것으로 보입니다.

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/83c7bba3-8bf2-43c3-8286-0d55cd033183" width ="200"> | <img src = "https://github.com/user-attachments/assets/c8f0be98-949e-481e-acfc-3b3d9a7e8387" width ="200"> | <img src = "https://github.com/user-attachments/assets/645a066b-188a-4b87-86fb-5ff8f4de7251" width ="200"> |


