### PR TITLE
[Refactor] #93 1차 자체 QA 수정 - 욱깃 

### DIFF
--- a/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
+++ b/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 				Info.plist,
 				Network/Base/.gitkeep,
 				Presentation/MyPage/ViewModel/.gitkeep,
-				Presentation/SharedWalk/ViewModel/.gitkeep,
 			);
 			target = 76ECCDEC2E05AFCC0056CAF7 /* PAWKEY */;
 		};

--- a/PAWKEY/PAWKEY/Global/Component/Chip/Chip.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Chip/Chip.swift
@@ -10,21 +10,23 @@ import SwiftUI
 struct Chip: View {
     let title: String
     var isActive: Bool = true
+    var textColor: Color = Color.pawkeyBlack
     
     var body: some View {
         Text(title)
             .font(.caption_12_r)
-            .foregroundStyle(isActive ? .green600 : .pawkeyBlack)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
+            .foregroundStyle(isActive ? .green600 : textColor)
             .background(isActive ? .green50 : .pawkeyWhite2)
             .clipShape(Capsule())
+            
     }
 }
 
 #Preview {
     ZStack {
         Color.gray
-        Chip(title: "옵션1", isActive: true)
+        Chip(title: "옵션1asdfsadfsdf", isActive: false)
     }
 }

--- a/PAWKEY/PAWKEY/Global/Component/Chip/Chip.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Chip/Chip.swift
@@ -10,14 +10,15 @@ import SwiftUI
 struct Chip: View {
     let title: String
     var isActive: Bool = true
-    var textColor: Color = Color.pawkeyBlack
+ //   var textColor: Color = Color.pawkeyBlack
+    var textColor: Color?
     
     var body: some View {
         Text(title)
             .font(.caption_12_r)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .foregroundStyle(isActive ? .green600 : textColor)
+            .foregroundStyle(textColor ?? (isActive ? .green600 : .pawkeyBlack))
             .background(isActive ? .green50 : .pawkeyWhite2)
             .clipShape(Capsule())
             
@@ -27,6 +28,6 @@ struct Chip: View {
 #Preview {
     ZStack {
         Color.gray
-        Chip(title: "옵션1asdfsadfsdf", isActive: false)
+        Chip(title: "옵션1asdfsadfsdf", isActive: true)
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
@@ -19,6 +19,9 @@ struct Review: Identifiable {
 
 struct MyCourseView: View {
     @EnvironmentObject var router: Coordinator<MyPageScreen>
+    
+    @EnvironmentObject var tabBarState: TabBarState
+    
     let tagList = ["이륜차 거의 없음", "배변 쓰레기통", "쉼터", "편의점", "동반 카페", "아스팔트/벽돌", "시끌벅적"]
     
     let myReviewList: [Review] = [
@@ -46,6 +49,7 @@ struct MyCourseView: View {
                         )
                         .onTapGesture {
                             router.push(.courseDetail)
+                            tabBarState.isHidden = true
                         }
                     }
                 }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
@@ -62,6 +62,7 @@ struct MyCourseView: View {
         .topNavigationView(left: {
             BackButton {
                 router.pop()
+                tabBarState.isHidden = false
             }
         }, center: {
             Text("내가 기록한 산책 루트")

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MyPageView: View {
     @EnvironmentObject var router: Coordinator<MyPageScreen>
+    @EnvironmentObject var tabBarState: TabBarState
     //@State var ownerName: String
     
     var body: some View {
@@ -41,6 +42,7 @@ struct MyPageView: View {
                     
                     Button {
                         router.push(.userProfile)
+                        tabBarState.isHidden = true
                     } label: {
                         Image(.arrowRightGray)
                     }
@@ -61,6 +63,7 @@ struct MyPageView: View {
                         Spacer()
                         Button {
                             router.push(.petProfile)
+                            tabBarState.isHidden = true
                         } label: {
                             Image(.arrowRightWhite)
                         }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
@@ -96,7 +96,7 @@ struct MyPageView: View {
                                 Chip(title: "#대형견", isActive: false, textColor: .gray400)
                                 Spacer()
                             }
-                            //.padding(.top, 16)
+                            .padding(.top, 16)
                         }
                         .padding(.leading, 16)
                         

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyPageView.swift
@@ -14,7 +14,7 @@ struct MyPageView: View {
     var body: some View {
         ScrollView(showsIndicators: false) {
             // 제목
-            VStack(spacing: 24) {
+            VStack(spacing: 16) {
                 HStack {
                     Text("마이페이지")
                         .font(.head_20_b)
@@ -22,20 +22,20 @@ struct MyPageView: View {
                         .padding(.leading, 16)
                     Spacer()
                 }
+                .padding(.bottom, 6)
                 
                 // 견주 프로필
                 HStack {
                     HStack {
-                        Text("김도기")
-                            .font(.head_18_sb)
-                            .foregroundColor(.pawkeyBlack)
-                        Text("님")
+                        Text("김도기 님")
                             .font(.head_18_sb)
                             .foregroundColor(.pawkeyBlack)
                         Text("견주")
                             .font(.caption_12_m)
                             .foregroundColor(.gray400)
                     }
+                    .padding(.leading, 16)
+                    .padding(.vertical, 24)
                     
                     Spacer()
                     
@@ -44,13 +44,12 @@ struct MyPageView: View {
                     } label: {
                         Image(.arrowRightGray)
                     }
-                    .padding(.vertical, 16)
+                    .padding(.vertical, 24)
+                    .padding(.trailing, 13)
                 }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
                 .background(Color.pawkeyWhite1)
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .frame(width: 343, height: 79)
+                .padding(.horizontal, 16)
                 
                 // 반려견 프로필
                 VStack(spacing: 0) {
@@ -91,13 +90,13 @@ struct MyPageView: View {
                             }
                             .padding(.top, 16)
                             
-                            HStack {
-                                Chip(title: "#조금느긋해요", isActive: false)
-                                Chip(title: "#오토바이소리", isActive: false)
-                                Chip(title: "#대형견", isActive: false)
+                            HStack(spacing: 8) {
+                                Chip(title: "#조금느긋해요", isActive: false, textColor: .gray400)
+                                Chip(title: "#오토바이소리", isActive: false, textColor: .gray400)
+                                Chip(title: "#대형견", isActive: false, textColor: .gray400)
                                 Spacer()
                             }
-                            .padding(.top, 16)
+                            //.padding(.top, 16)
                         }
                         .padding(.leading, 16)
                         
@@ -130,7 +129,7 @@ struct MyPageView: View {
                 }
                 .background(Color.pawkeyWhite1)
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .frame(width: 343, height: 255)
+                .padding(.horizontal, 16)
                 
                 
                 // 산책관리
@@ -161,8 +160,8 @@ struct MyPageView: View {
                     .onTapGesture {
                         router.push(.savedCourse)
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 16)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 20)
                     
                     Divider()
                         .padding(.horizontal, 16)
@@ -184,8 +183,8 @@ struct MyPageView: View {
                     .onTapGesture {
                         router.push(.myCourse)
                     }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 16)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 20)
                     
                     Divider()
                         .padding(.horizontal, 16)

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
@@ -127,6 +127,3 @@ struct PetProfileView: View {
     }
 }
 
-#Preview {
-    PetProfileView()
-}

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PetProfileView: View {
     @EnvironmentObject var router: Coordinator<MyPageScreen>
+    @EnvironmentObject var tabBarState: TabBarState
     
     var body: some View {
         VStack(spacing: 8) {
@@ -117,6 +118,7 @@ struct PetProfileView: View {
         .topNavigationView {
             BackButton {
                 router.pop()
+                tabBarState.isHidden = false
             }
         } center: {
             Text("반려견 프로필")

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PetProfileView: View {
-    @EnvironmentObject var router: Coordinator<MyPageScreen>
+   // @EnvironmentObject var router: Coordinator<MyPageScreen>
     
     var body: some View {
         VStack(spacing: 8) {
@@ -94,6 +94,9 @@ struct PetProfileView: View {
                                 .foregroundStyle(Color.green500)
                         }
                         .padding(.leading, 16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        Spacer()
                         
                         VStack(alignment: .leading, spacing: 10) {
                             Text("사회성 레벨")
@@ -103,9 +106,8 @@ struct PetProfileView: View {
                                 .font(.head_18_sb)
                                 .foregroundStyle(Color.green500)
                         }
-                        .padding(.leading, 32)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 
                 Spacer()
@@ -114,7 +116,7 @@ struct PetProfileView: View {
         .navigationBarBackButtonHidden()
         .topNavigationView {
             BackButton {
-                router.pop()
+                //router.pop()
             }
         } center: {
             Text("반려견 프로필")
@@ -123,4 +125,8 @@ struct PetProfileView: View {
         
         
     }
+}
+
+#Preview {
+    PetProfileView()
 }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/PetProfileView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PetProfileView: View {
-   // @EnvironmentObject var router: Coordinator<MyPageScreen>
+    @EnvironmentObject var router: Coordinator<MyPageScreen>
     
     var body: some View {
         VStack(spacing: 8) {
@@ -116,7 +116,7 @@ struct PetProfileView: View {
         .navigationBarBackButtonHidden()
         .topNavigationView {
             BackButton {
-                //router.pop()
+                router.pop()
             }
         } center: {
             Text("반려견 프로필")

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/SavedCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/SavedCourseView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SavedCourseView: View {
     @EnvironmentObject var router: Coordinator<MyPageScreen>
+    @EnvironmentObject var tabBarState: TabBarState
     
     let tagList = ["이륜차 거의 없음", "배변 쓰레기통", "쉼터", "편의점", "동반 카페", "아스팔트/벽돌", "시끌벅적"]
     let otherReviewList: [Review] = [
@@ -36,6 +37,7 @@ struct SavedCourseView: View {
                         )
                         .onTapGesture {
                             router.push(.courseDetail)
+                            tabBarState.isHidden = true
                         }
                     }
                 }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/UserProfileView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/UserProfileView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct UserProfileView: View {
     @EnvironmentObject var router: Coordinator<MyPageScreen>
+    @EnvironmentObject var tabBarState: TabBarState
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -67,7 +68,8 @@ struct UserProfileView: View {
         .topNavigationView(left: {
             BackButton {
                 router.pop()
-            }      
+                tabBarState.isHidden = false
+            }
         }, center: {
             Text("견주 프로필")
                 .font(.body_16_sb)

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CourseDetailView: View {
     @ObservedObject var viewModel: CourseDetailViewModel
-    @EnvironmentObject var tabBarstate: TabBarState
+    @EnvironmentObject var tabBarState: TabBarState
 //    @EnvironmentObject var router: Coordinator<HomeScreen>
     @EnvironmentObject var router: Coordinator<WalkScreen>
     
@@ -65,7 +65,7 @@ struct CourseDetailView: View {
         })
         .topNavigationView(left: {
             BackButton {
-                tabBarstate.isHidden = false
+                tabBarState.isHidden = false
                 router.pop()
             }
         }, center: {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #93 
## 👷 작업한 내용
- 마이페이지 horizzzzz 간격 조정
- 마이페이지 메뉴 상하 패딩 조정(석) 완료
- 반려견 프로필 디테일 수정이요 성향 간격 수정 완료
- 마이페이지에서 CourseDetailView 이동시 TabbarState.isHidden = true 만들어 버리기
- Chip 컴포넌트 수정


## ⚠️ 참고 사항
- 참고 기다리면 성과는 따라온다

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| 마이페이지 | <img src = "https://github.com/user-attachments/assets/50a30d04-1278-4725-beee-70176eff1ae0" width ="200"> | <img src = "https://github.com/user-attachments/assets/70d5c14d-b4ed-476c-9fa4-23b7abff0e9f" width ="200"> | <img src = "https://github.com/user-attachments/assets/39f57286-f150-4a2f-96e5-3583cb3ae57f" width ="200"> |
| 견주 프로필 | <img src = "https://github.com/user-attachments/assets/17d01b01-0d32-4a16-80b7-17fb282c9b35" width ="200"> | <img src = "https://github.com/user-attachments/assets/2117c921-ee91-4571-b87c-cf08da37a9e1" width ="200"> | <img src = "https://github.com/user-attachments/assets/c8002eb0-d784-430d-a260-277382e0951f" width ="200"> |
| 반려견 프로필 | <img src = "https://github.com/user-attachments/assets/abbc2cac-042b-4a89-9392-ca9a1e3a9df1" width ="200"> | <img src = "https://github.com/user-attachments/assets/e01e300a-3380-4f0f-924b-dafa17b6ca02" width ="200"> | <img src = "https://github.com/user-attachments/assets/90ede1c9-bffb-4a61-a58a-5d2ae4096f71" width ="200"> |
| 상세 코스 까지 | <img src = "https://github.com/user-attachments/assets/2f34f43b-a46e-4ad9-9de0-37ee8e89aa2c" width ="200"> | <img src = "https://github.com/user-attachments/assets/29ae03ad-a3be-43fc-97a3-4bc89095ee22" width ="200"> | <img src = "https://github.com/user-attachments/assets/1b71cfb0-5d7c-4797-8236-eb0ddbe7231e" width ="200"> |


<img width="204" height="192" alt="image" src="https://github.com/user-attachments/assets/73124d8d-159c-42e0-939f-e43c14643226" />

*이것이 코딩이다. 이것이 코딩이기 때문이다.. 끄덕*
