### PR TITLE
[Refactor] #92 1차 자체 QA 수정 - 셈깃

### DIFF
--- a/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
+++ b/PAWKEY/PAWKEY.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 				Info.plist,
 				Network/Base/.gitkeep,
 				Presentation/MyPage/ViewModel/.gitkeep,
-				Presentation/SharedWalk/ViewModel/.gitkeep,
 			);
 			target = 76ECCDEC2E05AFCC0056CAF7 /* PAWKEY */;
 		};

--- a/PAWKEY/PAWKEY/Global/Component/Common/QuestionForm.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Common/QuestionForm.swift
@@ -11,7 +11,7 @@ struct QuestionForm: View {
     let question: String
     let tags: [String]
     
-    @State private var selectedKeywords: Set<String> = []
+    @Binding var selectedTags: Set<String>
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -29,12 +29,12 @@ struct QuestionForm: View {
                 ReviewTagButton(
                     title: tag,
                     isSelected: Binding(
-                        get: { selectedKeywords.contains(tag) },
+                        get: { selectedTags.contains(tag) },
                         set: { newValue in
                             if newValue {
-                                selectedKeywords.insert(tag)
+                                selectedTags.insert(tag)
                             } else {
-                                selectedKeywords.remove(tag)
+                                selectedTags.remove(tag)
                             }
                         }
                     )

--- a/PAWKEY/PAWKEY/Global/Component/TabBar/TabBar.swift
+++ b/PAWKEY/PAWKEY/Global/Component/TabBar/TabBar.swift
@@ -10,41 +10,37 @@ import SwiftUI
 struct TabBar: View {
     @EnvironmentObject var tabBarState: TabBarState
     
+    private let tabBarWidth: CGFloat = 262
+    
     var body: some View {
-        GeometryReader { geo in
-            let buttonWidth = geo.size.width / CGFloat(TabBarItem.allCases.count)
+        let buttonWidth = tabBarWidth / CGFloat(TabBarItem.allCases.count)
+        
+        ZStack(alignment: .leading) {
+            Circle()
+                .fill(Color.white)
+                .frame(width: 48, height: 48)
+                .offset(x: indicatorOffset(buttonWidth: buttonWidth))
+                .animation(.easeInOut(duration: 0.2), value: tabBarState.selectedTab)
             
-            ZStack(alignment: .leading) {
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 48, height: 48)
-                    .offset(x: indicatorOffset(buttonWidth: buttonWidth))
-                    .animation(.easeInOut(duration: 0.2), value: tabBarState.selectedTab)
-                
-                HStack(spacing: 0) {
-                    ForEach(TabBarItem.allCases, id: \.self) { item in
-                        Button(action: {
-                            tabBarState.selectedTab = item
-                        }) {
-                            (tabBarState.selectedTab == item ? item.selectedImage : item.normalImage)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 24, height: 24)
-                                .frame(maxWidth: .infinity)
-                                .frame(height: 60)
-                        }
+            HStack(spacing: 0) {
+                ForEach(TabBarItem.allCases, id: \.self) { item in
+                    Button(action: {
+                        tabBarState.selectedTab = item
+                    }) {
+                        (tabBarState.selectedTab == item ? item.selectedImage : item.normalImage)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 24, height: 24)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 60)
                     }
                 }
             }
-            .frame(width: geo.size.width, height: 60)
-            .background(.pawkeyBlack)
-            .cornerRadius(200)
-            .shadow(color: .pawkeyBlack.opacity(0.25), radius: 2, x: 0, y: 4)
-            .padding(.bottom, 12)
-            .offset(y: tabBarState.isHidden ? 100 : 0)
-            .animation(.easeInOut(duration: 0.3), value: tabBarState.isHidden)
         }
-        .frame(width: 262, height: 60)
+        .frame(width: tabBarWidth, height: 60)
+        .background(Color.pawkeyBlack)
+        .cornerRadius(200)
+        .shadow(color: Color.pawkeyBlack.opacity(0.25), radius: 2, x: 0, y: 4)
         .padding(.horizontal, 6)
     }
     

--- a/PAWKEY/PAWKEY/Presentation/ActivityArea/View/ActivityAreaMapView.swift
+++ b/PAWKEY/PAWKEY/Presentation/ActivityArea/View/ActivityAreaMapView.swift
@@ -67,7 +67,9 @@ struct ActivityAreaMapView: View {
                                         showToast = false
                                     }
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                        tabBarState.isHidden = false
                                         router.reset()
+                                        
                                     }
                                 }
                             }

--- a/PAWKEY/PAWKEY/Presentation/ActivityArea/View/ActivityAreaMapView.swift
+++ b/PAWKEY/PAWKEY/Presentation/ActivityArea/View/ActivityAreaMapView.swift
@@ -66,6 +66,9 @@ struct ActivityAreaMapView: View {
                                     withAnimation {
                                         showToast = false
                                     }
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                        router.reset()
+                                    }
                                 }
                             }
                             .padding(.horizontal, 16)

--- a/PAWKEY/PAWKEY/Presentation/MainTab/MainTabView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MainTab/MainTabView.swift
@@ -34,7 +34,11 @@ struct MainTabView: View {
                 Spacer()
                 
                 TabBar()
+                    .padding(.bottom, 12)
+                    .offset(y: tabBarState.isHidden ? 100 : 0)
+                    .animation(.easeInOut(duration: 0.3), value: tabBarState.isHidden)
             }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -17,7 +17,7 @@ struct MapAndListView: View {
     
     @State private var selectedMode: Int = 0
     @State private var showWalkCourseView = false
-    @State private var userTrackingMode: MKUserTrackingMode = .follow
+    @State private var userTrackingMode: MKUserTrackingMode = .none
     @State private var shouldCenterOnUser: Bool = false
     
     @Namespace private var namespace

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CoreLocation
+import MapKit
 
 struct MapAndListView: View {
     @EnvironmentObject var router: Coordinator<WalkScreen>
@@ -16,6 +17,7 @@ struct MapAndListView: View {
     
     @State private var selectedMode: Int = 0
     @State private var showWalkCourseView = false
+    @State private var userTrackingMode: MKUserTrackingMode = .follow
     @State private var shouldCenterOnUser: Bool = false
     
     @Namespace private var namespace
@@ -46,7 +48,8 @@ struct MapAndListView: View {
                     WalkMap(region: $viewModel.region,
                             pathCoordinates: $viewModel.pathCoordinates,
                             shouldCenterOnUser: $shouldCenterOnUser,
-                            snapshotImage: .constant(nil))
+                            snapshotImage: .constant(nil),
+                            userTrackingMode: $userTrackingMode)
                     .edgesIgnoringSafeArea(.bottom)
                     .overlay(
                         VStack {

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ReviewWriteView: View {
+    @StateObject private var viewModel = ReviewWriteViewModel()
     
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -59,29 +60,31 @@ struct ReviewWriteView: View {
                         .foregroundStyle(.gray200)
                         .padding(.bottom, 23)
                     
-//                    VStack(alignment: .leading, spacing: 32) {
-//                        QuestionForm(
-//                            question: "🚸 산책 중 안전 요소는 어땠나요?",
-//                            tags: [
-//                                "킥보드나 자전거가 거의 없어요",
-//                                "차량이 거의 다니지 않아요",
-//                                "야간 조명이 잘 되어있어요",
-//                                "보도와 차도가 구분되어 있어요",
-//                                "보도가 넓어서 산책하기 편했어요"
-//                            ]
-//                        )
-//                        
-//                        QuestionForm(
-//                            question: "🧺 산책 중 어떤 편의 시설이 있었나요?",
-//                            tags: [
-//                                "배변 봉투 쓰레기통이 있어요",
-//                                "애견 산책로가 있어요",
-//                                "쉴 곳이 있어요",
-//                                "편의점이 있어요",
-//                                "반려견 동반 가능한 카페가 있어요"
-//                            ]
-//                        )
-//                    }
+                    VStack(alignment: .leading, spacing: 32) {
+                        QuestionForm(
+                            question: "🚸 산책 중 안전 요소는 어땠나요?",
+                            tags: [
+                                "킥보드나 자전거가 거의 없어요",
+                                "차량이 거의 다니지 않아요",
+                                "야간 조명이 잘 되어있어요",
+                                "보도와 차도가 구분되어 있어요",
+                                "보도가 넓어서 산책하기 편했어요"
+                            ],
+                            selectedTags: $viewModel.safetyTags
+                        )
+                        
+                        QuestionForm(
+                            question: "🧺 산책 중 어떤 편의 시설이 있었나요?",
+                            tags: [
+                                "배변 봉투 쓰레기통이 있어요",
+                                "애견 산책로가 있어요",
+                                "쉴 곳이 있어요",
+                                "편의점이 있어요",
+                                "반려견 동반 가능한 카페가 있어요"
+                            ],
+                            selectedTags: $viewModel.facilityTags
+                        )
+                    }
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)
@@ -95,7 +98,7 @@ struct ReviewWriteView: View {
                 
                 CTAButton(
                     title: "산책 후기 남기기",
-                    isDisabled: false,
+                    isDisabled: !viewModel.isButtonDisabled,
                     buttonStyle: .filled
                 ) {
                     

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
@@ -104,7 +104,7 @@ struct ReviewWriteView: View {
                 .padding(.bottom, 30)
             }
             .topNavigationView(center: {
-                Text("산책 완료")
+                Text("산책 후기 작성")
                     .font(.body_16_sb)
             })
         }

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/ReviewWriteView.swift
@@ -59,29 +59,29 @@ struct ReviewWriteView: View {
                         .foregroundStyle(.gray200)
                         .padding(.bottom, 23)
                     
-                    VStack(alignment: .leading, spacing: 32) {
-                        QuestionForm(
-                            question: "🚸 산책 중 안전 요소는 어땠나요?",
-                            tags: [
-                                "킥보드나 자전거가 거의 없어요",
-                                "차량이 거의 다니지 않아요",
-                                "야간 조명이 잘 되어있어요",
-                                "보도와 차도가 구분되어 있어요",
-                                "보도가 넓어서 산책하기 편했어요"
-                            ]
-                        )
-                        
-                        QuestionForm(
-                            question: "🧺 산책 중 어떤 편의 시설이 있었나요?",
-                            tags: [
-                                "배변 봉투 쓰레기통이 있어요",
-                                "애견 산책로가 있어요",
-                                "쉴 곳이 있어요",
-                                "편의점이 있어요",
-                                "반려견 동반 가능한 카페가 있어요"
-                            ]
-                        )
-                    }
+//                    VStack(alignment: .leading, spacing: 32) {
+//                        QuestionForm(
+//                            question: "🚸 산책 중 안전 요소는 어땠나요?",
+//                            tags: [
+//                                "킥보드나 자전거가 거의 없어요",
+//                                "차량이 거의 다니지 않아요",
+//                                "야간 조명이 잘 되어있어요",
+//                                "보도와 차도가 구분되어 있어요",
+//                                "보도가 넓어서 산책하기 편했어요"
+//                            ]
+//                        )
+//                        
+//                        QuestionForm(
+//                            question: "🧺 산책 중 어떤 편의 시설이 있었나요?",
+//                            tags: [
+//                                "배변 봉투 쓰레기통이 있어요",
+//                                "애견 산책로가 있어요",
+//                                "쉴 곳이 있어요",
+//                                "편의점이 있어요",
+//                                "반려견 동반 가능한 카페가 있어요"
+//                            ]
+//                        )
+//                    }
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCompletionView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCompletionView.swift
@@ -27,7 +27,6 @@ struct SharedWalkCompletionView: View {
                     .foregroundColor(.pawkeyBlack)
                     .padding(.top, 36)
                     .padding(.bottom, 16)
-                    .padding(.horizontal, 16)
                 
                 VStack(alignment: .leading) {
                     HStack(alignment: .center, spacing: 10) {
@@ -71,7 +70,6 @@ struct SharedWalkCompletionView: View {
                 .padding(.bottom, 8)
                 .background(.pawkeyWhite1)
                 .cornerRadius(16)
-                .padding(.horizontal, 16)
                 
                 Spacer()
                 

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
@@ -43,6 +43,7 @@ struct SharedWalkCourseView: View {
                 
                 if showStopConfirmation {
                     StopConfirmationView(
+                        description: "아직 설정된 산책 루트를 다 돌지 못했어요.",
                         onResume: {
                             showStopConfirmation = false
                             viewModel.setPaused(false)
@@ -62,7 +63,7 @@ struct SharedWalkCourseView: View {
                     Spacer()
                     
                     CTAButton(
-                        title: "종료하기",
+                        title: "산책 기록 중지",
                         isDisabled: false,
                         buttonStyle: .filled
                     ) {

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
@@ -17,7 +17,7 @@ struct SharedWalkCourseView: View {
     
     @State private var showStopConfirmation = false
     
-    @State private var userTrackingMode: MKUserTrackingMode = .follow
+    @State private var userTrackingMode: MKUserTrackingMode = .none
     
     let onComplete: (Double, String, Int, UIImage?) -> Void
     

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkCourseView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import MapKit
 
 struct SharedWalkCourseView: View {
     @EnvironmentObject var router: Coordinator<WalkScreen>
@@ -16,6 +17,8 @@ struct SharedWalkCourseView: View {
     
     @State private var showStopConfirmation = false
     
+    @State private var userTrackingMode: MKUserTrackingMode = .follow
+    
     let onComplete: (Double, String, Int, UIImage?) -> Void
     
     var body: some View {
@@ -24,6 +27,7 @@ struct SharedWalkCourseView: View {
                 SharedWalkMap(
                     region: $viewModel.region,
                     shouldCenterOnUser: $viewModel.shouldCenterOnUser,
+                    userTrackingMode: $userTrackingMode,
                     pathCoordinates: viewModel.examplePathCoordinates
                 )
                 .edgesIgnoringSafeArea(.all)

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkMap.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/View/SharedWalkMap.swift
@@ -11,6 +11,7 @@ import MapKit
 struct SharedWalkMap: UIViewRepresentable {
     @Binding var region: MKCoordinateRegion
     @Binding var shouldCenterOnUser: Bool
+    @Binding var userTrackingMode: MKUserTrackingMode
     var pathCoordinates: [CLLocationCoordinate2D]
     
     func makeUIView(context: Context) -> MKMapView {
@@ -18,10 +19,14 @@ struct SharedWalkMap: UIViewRepresentable {
         mapView.showsUserLocation = true
         mapView.delegate = context.coordinator
         mapView.setRegion(region, animated: false)
+        
+        mapView.userTrackingMode = .followWithHeading
         return mapView
     }
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
+        uiView.setUserTrackingMode(userTrackingMode, animated: true)
+        
         if shouldCenterOnUser {
             uiView.setRegion(region, animated: true)
             DispatchQueue.main.async {

--- a/PAWKEY/PAWKEY/Presentation/SharedWalk/ViewModel/ReviewWriteViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/SharedWalk/ViewModel/ReviewWriteViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  ReviewWriteViewModel.swift
+//  PAWKEY
+//
+//  Created by 이세민 on 7/14/25.
+//
+
+import SwiftUI
+
+class ReviewWriteViewModel: ObservableObject {
+    @Published var safetyTags: Set<String> = []
+    @Published var facilityTags: Set<String> = []
+    
+    var isButtonDisabled: Bool {
+        !safetyTags.isEmpty &&
+        !facilityTags.isEmpty
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
@@ -103,7 +103,8 @@ struct ArchiveView: View {
                                 "야간 조명이 잘 되어있어요",
                                 "보도와 차도가 구분되어 있어요",
                                 "보도가 넓어서 산책하기 편했어요"
-                            ]
+                            ],
+                            selectedTags: $viewModel.safetyTags
                         )
                         
                         QuestionForm(
@@ -114,7 +115,8 @@ struct ArchiveView: View {
                                 "쉴 곳이 있어요",
                                 "편의점이 있어요",
                                 "반려견 동반 가능한 카페가 있어요"
-                            ]
+                            ],
+                            selectedTags: $viewModel.facilityTags
                         )
                     }
                 }
@@ -134,9 +136,8 @@ struct ArchiveView: View {
                         .foregroundStyle(.pawkeyBlack)
                         .padding(.bottom, 10)
                     
-                    ReviewTextField(type: .normal, text: $titleText)
-                    
-                    ReviewTextEditor(text: $reviewText)
+                    ReviewTextField(type: .normal, text: $viewModel.titleText)
+                    ReviewTextEditor(text: $viewModel.reviewText)
                 }
                 .padding(.horizontal, 16)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -148,11 +149,11 @@ struct ArchiveView: View {
                     .padding(.vertical, 24)
                 
                 VStack(spacing: 13) {
-                    CTAButton(title: "산책 기록 공유하기", isDisabled: false, buttonStyle: .filled) {
+                    CTAButton(title: "산책 기록 공유하기", isDisabled: !viewModel.isButtonDisabled, buttonStyle: .filled) {
                         pushCourseDetail(isPrivate: false)
                     }
-                    
-                    CTAButton(title: "산책 기록 나만보기", isDisabled: false, buttonStyle: .text) {
+
+                    CTAButton(title: "산책 기록 나만보기", isDisabled: !viewModel.isButtonDisabled, buttonStyle: .text) {
                         pushCourseDetail(isPrivate: true)
                     }
                 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCompletionView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCompletionView.swift
@@ -27,7 +27,6 @@ struct WalkCompletionView: View {
                     .foregroundColor(.pawkeyBlack)
                     .padding(.top, 36)
                     .padding(.bottom, 16)
-                    .padding(.horizontal, 16)
                 
                 VStack(alignment: .leading) {
                     HStack(alignment: .center, spacing: 10) {
@@ -71,7 +70,6 @@ struct WalkCompletionView: View {
                 .padding(.bottom, 8)
                 .background(.pawkeyWhite1)
                 .cornerRadius(16)
-                .padding(.horizontal, 16)
                 
                 Spacer()
                 

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import MapKit
 
 struct WalkCourseView: View {
     @EnvironmentObject var router: Coordinator<WalkScreen>
@@ -16,6 +17,8 @@ struct WalkCourseView: View {
     
     @State private var showStopConfirmation = false
     
+    @State private var userTrackingMode: MKUserTrackingMode = .follow
+    
     let onComplete: (Double, String, Int, UIImage?) -> Void
     
     var body: some View {
@@ -25,7 +28,8 @@ struct WalkCourseView: View {
                     region: $viewModel.region,
                     pathCoordinates: $viewModel.pathCoordinates,
                     shouldCenterOnUser: $viewModel.shouldCenterOnUser,
-                    snapshotImage: .constant(nil)
+                    snapshotImage: .constant(nil),
+                    userTrackingMode: $userTrackingMode
                 )
                 .edgesIgnoringSafeArea(.all)
                 

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
@@ -44,6 +44,7 @@ struct WalkCourseView: View {
                 
                 if showStopConfirmation {
                     StopConfirmationView(
+                        description: "산책을 정말 종료하시겠어요?",
                         onResume: {
                             showStopConfirmation = false
                             viewModel.setPaused(false)
@@ -101,6 +102,7 @@ struct WalkCourseView: View {
 }
 
 struct StopConfirmationView: View {
+    let description: String
     let onResume: () -> Void
     let onStop: () -> Void
     
@@ -115,7 +117,7 @@ struct StopConfirmationView: View {
                 .padding(.horizontal, 88)
                 .padding(.bottom, 12)
             
-            Text("산책을 정말 종료하시겠어요?")
+            Text(description)
                 .font(.body_16_m)
                 .foregroundColor(.pawkeyWhite2)
                 .frame(maxWidth: .infinity)
@@ -139,7 +141,7 @@ struct StopConfirmationView: View {
                 }
                 
                 CTAButton(
-                    title: "산책 종료하기",
+                    title: "산책 기록 중지",
                     isDisabled: false,
                     buttonStyle: .filled,
                     action: onStop

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/WalkCourseView.swift
@@ -117,15 +117,11 @@ struct StopConfirmationView: View {
             Text("산책이 중단되었어요.")
                 .font(.head_24_b)
                 .foregroundColor(.pawkeyWhite1)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 88)
                 .padding(.bottom, 12)
             
             Text(description)
                 .font(.body_16_m)
                 .foregroundColor(.pawkeyWhite2)
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 96)
             
             Spacer()
             

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/WalkMap.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/WalkMap.swift
@@ -21,6 +21,8 @@ struct WalkMap: UIViewRepresentable {
     // 스냅샷
     @Binding var snapshotImage: UIImage?
     
+    @Binding var userTrackingMode: MKUserTrackingMode
+    
     
     // MKMapView 초기 설정
     func makeUIView(context: Context) -> MKMapView {
@@ -28,11 +30,15 @@ struct WalkMap: UIViewRepresentable {
         mapView.showsUserLocation = true
         mapView.delegate = context.coordinator
         mapView.setRegion(region, animated: false)
+        
+        mapView.userTrackingMode = .followWithHeading
         return mapView
     }
     
     // 상태값이 바뀌면 여기서 MKMapView를 갱신
     func updateUIView(_ uiView: MKMapView, context: Context) {
+        uiView.setUserTrackingMode(userTrackingMode, animated: true)
+        
         if shouldCenterOnUser {
             uiView.setRegion(region, animated: true)
             DispatchQueue.main.async {
@@ -92,6 +98,6 @@ struct WalkMap: UIViewRepresentable {
             
             return nil
         }
-
+        
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
@@ -12,6 +12,19 @@ class ArchiveViewModel: ObservableObject {
     @Published var selectedItems: [PhotosPickerItem] = []
     @Published var selectedImages: [UIImage] = []
     
+    @Published var safetyTags: Set<String> = []
+    @Published var facilityTags: Set<String> = []
+    
+    @Published var titleText: String = ""
+    @Published var reviewText: String = ""
+    
+    var isButtonDisabled: Bool {
+        !titleText.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !reviewText.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !safetyTags.isEmpty &&
+        !facilityTags.isEmpty
+    }
+    
     @MainActor
     func loadImagesFromPicker() async {
         var newImages: [UIImage] = []


### PR DESCRIPTION
## 📟 연결된 이슈
closed #92 

## 👷 작업한 내용
- 지역 변경하기 누르면 토스트 메세지 뜨고 홈으로
- 지역 변경 후 홈으로 가면서 탭바 나타나기
- 산책 시 맵도 이동
- 탭바 레이아웃
- 산책 완료 뷰 horizontal 패딩
- 버튼 타이틀 종료하기 → 산책 기록 중지 로 수정
- 디스크립션 아직 설정된 산책 루트를 다 돌지 못했어요 🥲 로 수정
- ReviewWriteView 에서 네비게이션 타이틀 산책 완료 → 산책 후기 작성 로 수정
- 기록하기 버튼 비활성화 제어
- 리뷰 남기기 버튼 비활성화 제어

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/ffd4db65-f6ef-40e5-a051-2ab971704c8e" width ="200"> | <img src = "https://github.com/user-attachments/assets/6bb82138-7207-4392-822a-b1f2e6b2cebb" width ="200"> | <img src = "https://github.com/user-attachments/assets/46d5f8e6-5c2a-44b8-8f6d-8022a86c0f6e" width ="200"> |
