### PR TITLE
[Network] #110 지역구 리스트 조회 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Network/Region/RegionAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Region/RegionAPI.swift
@@ -1,0 +1,44 @@
+//
+//  RegionAPI.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/15/25.
+//
+
+import Foundation
+
+import Moya
+
+enum RegionAPI {
+    case fetchRegions
+}
+
+extension RegionAPI: BaseTargetType {
+    var headerType: HeaderType {
+        switch self {
+        case .fetchRegions:
+            return .userHeader(userId: 2)
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchRegions:
+            return "pets/traits/regions"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchRegions:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .fetchRegions:
+            return .requestPlain
+        }
+    }
+}

--- a/PAWKEY/PAWKEY/Network/Region/RegionAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Region/RegionAPI.swift
@@ -24,7 +24,7 @@ extension RegionAPI: BaseTargetType {
     var path: String {
         switch self {
         case .fetchRegions:
-            return "pets/traits/regions"
+            return "regions"
         }
     }
     

--- a/PAWKEY/PAWKEY/Network/Region/RegionDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Region/RegionDTO.swift
@@ -1,0 +1,22 @@
+//
+//  RegionDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/15/25.
+//
+
+import Foundation
+
+struct DistrictDTO: Codable {
+    let districtDtos: [DistrictUnitDTO]
+}
+
+struct DistrictUnitDTO: Codable {
+    let gu: AreaDTO
+    let dongs: [AreaDTO]
+}
+
+struct AreaDTO: Codable {
+    let id: Int
+    let name: String
+}

--- a/PAWKEY/PAWKEY/Network/Region/RegionDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Region/RegionDTO.swift
@@ -20,3 +20,21 @@ struct AreaDTO: Codable {
     let id: Int
     let name: String
 }
+
+extension Array where Element == DistrictUnitDTO {
+    func toEntity() -> [RegionUnit] {
+        map { RegionUnit(gu: $0.gu.toEntity(), dong: $0.dongs.toEntity())}
+    }
+}
+
+extension AreaDTO {
+    func toEntity() -> Area {
+        Area(id: id, name: name)
+    }
+}
+
+extension Array where Element == AreaDTO {
+    func toEntity() -> [Area] {
+        map { Area(id: $0.id, name: $0.name )}
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/Register/Model/Region.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/Model/Region.swift
@@ -1,0 +1,22 @@
+//
+//  Region.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/15/25.
+//
+
+import Foundation
+
+struct RegionData {
+    let regions: [RegionUnit]
+}
+
+struct RegionUnit: Hashable {
+    let gu: Area
+    let dong: [Area]
+}
+
+struct Area: Hashable {
+    let id: Int
+    let name: String
+}

--- a/PAWKEY/PAWKEY/Presentation/Register/View/ActivityAreaView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/View/ActivityAreaView.swift
@@ -27,29 +27,32 @@ struct ActivityAreaView: View {
                     Text("지역구")
                         .font(.body_14_sb)
                     FlexibleGrid(availableWidth: proxy.size.width - 32,
-                                     data: viewModel.regionList,
-                                     spacing: 14,
-                                     alignment: .leading, content: {
-                        LocationButton($0, type: .small, isSelected: $0 == viewModel.userProfile.region) { region in
-                            viewModel.changeUserInfo(.region(region))
-                        }
+                                 data: viewModel.regions.map { $0.gu },
+                                 spacing: 14,
+                                 alignment: .leading, content: { region in
+                        LocationButton(region.name, type: .small, isSelected: region.id == viewModel.selectedRegiondId)
+                            .disabled(true)
+                            .onTapGesture {
+                                viewModel.selecteRegion(region.id)
+                            }
                     })
                     .clipped()
                 }
                 
                 Spacer().frame(height: 42)
-                
-                if !viewModel.userProfile.region.isEmpty {
+                if let selectedLegalRegions = viewModel.selectedLegalRegions {
                     VStack(alignment: .leading) {
                         Text("법정동")
                             .font(.body_14_sb)
                         FlexibleGrid(availableWidth: proxy.size.width - 32,
-                                         data: viewModel.legalRegionList,
-                                         spacing: 14,
-                                         alignment: .leading, content: {
-                            LocationButton($0, type: .small, isSelected: $0 == viewModel.userProfile.legalRegion) { legalRegion in
-                                viewModel.changeUserInfo(.legalRegion(legalRegion))
-                            }
+                                     data: selectedLegalRegions,
+                                     spacing: 14,
+                                     alignment: .leading, content: { legalRegion in
+                            LocationButton(legalRegion.name, type: .small, isSelected: viewModel.userProfile.regionId == legalRegion.id)
+                                .disabled(true)
+                                .onTapGesture {
+                                    viewModel.changeUserInfo(.region(legalRegion.id))
+                                }
                         })
                         .padding(.trailing, 72)
                     }
@@ -58,6 +61,9 @@ struct ActivityAreaView: View {
                 Spacer()
             }
             .padding(.horizontal, 16)
+        }
+        .task {
+            await viewModel.fetchRegions()
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -75,7 +75,7 @@ final class ProfileSetUpViewModel: ObservableObject {
     @Published var userProfile = UserProfile()
     @Published var petTraitsCategories: [PetTraitCategory] = []
     @Published var regions: [RegionUnit] = []
-    @Published var selectedRegiondId = 0
+    @Published var selectedRegiondId: Int?
     
     @Published var errorMessage: String?
     

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -56,14 +56,10 @@ final class ProfileSetUpViewModel: ObservableObject {
         
         var title: String {
             switch self {
-            case .ownerInfo:
-                "회원가입"
-            case .activityArea:
-                "회원가입"
-            case .dogInfo:
-                "반려견 등록하기"
-            case .dogTendency:
-                "반려견 등록하기"
+            case .ownerInfo: "회원가입"
+            case .activityArea: "회원가입"
+            case .dogInfo: "반려견 등록하기"
+            case .dogTendency: "반려견 등록하기"
             }
         }
     }
@@ -146,7 +142,7 @@ final class ProfileSetUpViewModel: ObservableObject {
                   let optionId = userProfile.petTraits[selectedCategoryId].categoryOptions.firstIndex(where: {$0.categoryOptionId == optionId}) else { return }
             
             userProfile.petTraits[selectedCategoryId].categoryOptions = petTraitsCategories[selectedCategoryId].categoryOptions
-            userProfile.petTraits[categoryId].categoryOptions[optionId].isSelected.toggle()
+            userProfile.petTraits[selectedCategoryId].categoryOptions[optionId].isSelected.toggle()
             
         case .dogBreed(let dogBreed):
             userProfile.dogBreed = dogBreed

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -12,8 +12,7 @@ struct UserProfile {
     var userName: String = ""
     var userGender: String = ""
     var userAge: String = ""
-    var region: String = ""
-    var legalRegion: String = ""
+    var regionId: Int = 0
     var dogName: String = ""
     var dogAge: String = ""
     var dogGender: String = ""
@@ -36,8 +35,7 @@ enum ProfileField {
     case userName(String)
     case userGender(String)
     case userAge(String)
-    case region(String)
-    case legalRegion(String)
+    case region(Int)
     case dogName(String)
     case dogGender(String)
     case KnownDogAge(KnownDogAge?)
@@ -64,26 +62,26 @@ final class ProfileSetUpViewModel: ObservableObject {
         }
     }
     
-    private let provider = MoyaProvider<PetTraitsCategoryAPI>()
-    
     // 모델(임시)
     let genderList = ["남자", "여자"]
-    let regionList = ["강남구"]
-    let legalRegionList = [
-        "개포동", "논현동", "대치동", "도곡동", "삼성동",
-        "세곡동", "수서동", "신사동", "압구정동", "역삼동",
-        "율현동", "자곡동", "청담동", "일원동"
-    ]
     let dogGenderList = ["남아", "여아"]
     let knownDogAgeList = ["나이를 알아요", "나이를 몰라요"]
     
-    @Published var userProfile = UserProfile()
+    // View state
     @Published var currentStep: ProfileStep = .ownerInfo
     @Published var isKeyboardVisible = false
     
+    // User state
+    @Published var userProfile = UserProfile()
     @Published var petTraitsCategories: [PetTraitCategory] = []
+    @Published var regions: [RegionUnit] = []
+    @Published var selectedRegiondId = 0
+    
     @Published var errorMessage: String?
     
+    var selectedLegalRegions: [Area]? {
+        regions.first(where: {$0.gu.id == selectedRegiondId })?.dong
+    }
     var currentStepIndex: Int { currentStep.rawValue }
     var isButtonDisabled: Bool {
         switch currentStep {
@@ -93,8 +91,7 @@ final class ProfileSetUpViewModel: ObservableObject {
             userProfile.userAge.isEmpty
             
         case .activityArea:
-            return userProfile.region.isEmpty ||
-            userProfile.legalRegion.isEmpty
+            return userProfile.regionId == 0
             
         case .dogInfo:
             return userProfile.dogName.isEmpty ||
@@ -102,13 +99,15 @@ final class ProfileSetUpViewModel: ObservableObject {
             userProfile.dogBreed.isEmpty ||
             userProfile.knownDogAge == .none ||
             (userProfile.isKnownAge && userProfile.dogAge.isEmpty)
-            
         case .dogTendency:
             return petTraitsCategories.count != userProfile.petTraits.flatMap { $0.categoryOptions }.filter {$0.isSelected}.count
         }
     }
-    
-    // MARK: - State Method
+}
+
+// MARK: - State Method
+
+extension ProfileSetUpViewModel {
     
     func goToNextStep() {
         currentStep = ProfileStep(rawValue: currentStep.rawValue + 1) ?? .dogTendency
@@ -126,10 +125,8 @@ final class ProfileSetUpViewModel: ObservableObject {
             userProfile.userGender = gender
         case .userAge(let age):
             userProfile.userAge = age
-        case .region(let region):
-            userProfile.region = region
-        case .legalRegion(let legal):
-            userProfile.legalRegion = legal
+        case .region(let regionId):
+            userProfile.regionId = regionId
         case .dogName(let name):
             userProfile.dogName = name
         case .dogGender(let gender):
@@ -143,7 +140,6 @@ final class ProfileSetUpViewModel: ObservableObject {
             
             userProfile.petTraits[selectedCategoryId].categoryOptions = petTraitsCategories[selectedCategoryId].categoryOptions
             userProfile.petTraits[selectedCategoryId].categoryOptions[optionId].isSelected.toggle()
-            
         case .dogBreed(let dogBreed):
             userProfile.dogBreed = dogBreed
         case .neutered(let neutered):
@@ -151,10 +147,19 @@ final class ProfileSetUpViewModel: ObservableObject {
         }
     }
     
-    // MARK: - API
+    func selecteRegion(_ regionId: Int) {
+        selectedRegiondId = regionId
+    }
+}
+
+// MARK: - API
+
+extension ProfileSetUpViewModel {
     
     @MainActor
     func fetchPetTraitsCategories() async {
+        let provider = MoyaProvider<PetTraitsCategoryAPI>()
+        
         do {
             let response: BaseDTO<PetTraitDTO> = try await provider.async.request(.fetchPetTraitsCategories)
             
@@ -165,6 +170,25 @@ final class ProfileSetUpViewModel: ObservableObject {
             
             self.petTraitsCategories = data.petTraitCategoryList.map {$0.toEntity()}
             self.userProfile.petTraits = data.petTraitCategoryList.map {$0.toEntity()}
+        } catch {
+            errorMessage = "에러 발생: \(error.localizedDescription)"
+        }
+    }
+    
+    @MainActor
+    func fetchRegions() async {
+        let provider = MoyaProvider<RegionAPI>()
+        
+        do {
+            let response: BaseDTO<DistrictDTO> = try await provider.async.request(.fetchRegions)
+            
+            guard let data = response.data else {
+                errorMessage = "에러 발생: 데이터를 찾을 수 없음"
+                return
+            }
+            
+            self.regions = data.districtDtos.toEntity()
+            
         } catch {
             errorMessage = "에러 발생: \(error.localizedDescription)"
         }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #110 

## 👷 작업한 내용
- 지역구 리스트 조회 API를 연동했습니다
- 관련된 APIService, DTO 등을 추가했습니다
- 기존의 목데이터를 삭제하고 실제 데이터를 받아오도록 처리

## ⌨️ 주요 코드 설명
`ProfileSetUpViewModel`:
서버에서 받아온 지역구 리스트 데이터를 regions에 저장하고 selectedRegiondId에 지역구 id를 저장합니다. 이또한 유저 정보 등록 API 연동시 한번에 보낼 데이터로 UserProfile 모델의 region 이름또한 서버의 명세엥 맞도록 regionId 으로 수정했습니다.
```swift
    @Published var regions: [RegionUnit] = []
    @Published var selectedRegiondId = 0

struct UserProfile {
    var userName: String = ""
    var userGender: String = ""
    var userAge: String = ""
    var regionId: Int = 0 // 이곳수정
    var dogName: String = ""
    var dogAge: String = ""
    var dogGender: String = ""
    var petTraits: [PetTraitCategory] = []
    var knownDogAge: KnownDogAge?
    var dogBreed: String = ""
    var isNeutered = false
    
    var isKnownAge: Bool {
        knownDogAge == .known
    }
}
```

## ⚠️ 참고 사항
- 참고 사항

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "https://github.com/user-attachments/assets/c4b1aef5-09bd-4499-9593-0a8f6188fb2b" width ="200"> |
