### PR TITLE
[Network] #116 산책 루트 정보 조회, 게시글(기록) 카테고리 조회, 게시물 등록 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Network/ActivityArea/ActivityAreaMapAPI.swift
+++ b/PAWKEY/PAWKEY/Network/ActivityArea/ActivityAreaMapAPI.swift
@@ -11,7 +11,7 @@ import Moya
 
 enum ActivityAreaMapAPI {
     case fetchCoordinates(regionId: Int)
-    case updateUserRegion(regionId: Int)
+    case updateUserRegion
 }
 
 extension ActivityAreaMapAPI: BaseTargetType {
@@ -44,9 +44,9 @@ extension ActivityAreaMapAPI: BaseTargetType {
         switch self {
         case .fetchCoordinates:
             return .requestPlain
-        case .updateUserRegion(let regionId):
+        case .updateUserRegion:
             return .requestParameters(
-                parameters: ["regionId": regionId],
+                parameters: ["regionId": 40],
                 encoding: JSONEncoding.default
             )
         }

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
@@ -5,17 +5,19 @@
 //  Created by 이세민 on 7/15/25.
 //
 
+import Foundation
 import Moya
 
 enum ArchiveAPI {
     case fetchCourseInfo(routeId: Int)
     case fetchCourseCategories
+    case postCourse(body: ArchivePostDTO, images: [Data]?)
 }
 
 extension ArchiveAPI: BaseTargetType {
     var headerType: HeaderType {
         switch self {
-        case .fetchCourseInfo, .fetchCourseCategories:
+        case .fetchCourseInfo, .fetchCourseCategories, .postCourse:
             return .userHeader(userId: 2)
         }
     }
@@ -26,14 +28,50 @@ extension ArchiveAPI: BaseTargetType {
             return "routes/\(routeId)/info"
         case .fetchCourseCategories:
             return "posts/categories"
+        case .postCourse:
+            return "posts"
         }
     }
     
     var method: Moya.Method {
-        return .get
+        switch self {
+        case .postCourse:
+            return .post
+        default:
+            return .get
+        }
     }
     
     var task: Task {
-        return .requestPlain
+        switch self {
+        case .fetchCourseInfo, .fetchCourseCategories:
+            return .requestPlain
+            
+        case .postCourse(let body, let images):
+            var multipartData: [MultipartFormData] = []
+            
+            if let jsonData = try? JSONEncoder().encode(body) {
+                let jsonPart = MultipartFormData(
+                    provider: .data(jsonData),
+                    name: "data",
+                    mimeType: "application/json"
+                )
+                multipartData.append(jsonPart)
+            }
+            
+            if let images = images {
+                for (index, imageData) in images.enumerated() {
+                    let imagePart = MultipartFormData(
+                        provider: .data(imageData),
+                        name: "images",
+                        fileName: "snapshot\(index).jpg",
+                        mimeType: "multipart-form-data"
+                    )
+                    multipartData.append(imagePart)
+                }
+            }
+            return .uploadMultipart(multipartData)
+        }
     }
+    
 }

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
@@ -1,0 +1,36 @@
+//
+//  ArchiveAPI.swift
+//  PAWKEY
+//
+//  Created by 이세민 on 7/15/25.
+//
+
+import Moya
+
+enum ArchiveAPI {
+    case fetchCourseInfo(routeId: Int)
+}
+
+extension ArchiveAPI: BaseTargetType {
+    var headerType: HeaderType {
+        switch self {
+        case .fetchCourseInfo:
+            return .userHeader(userId: 2)
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .fetchCourseInfo(let routeId):
+            return "routes/\(routeId)/info"
+        }
+    }
+
+    var method: Moya.Method {
+        return .get
+    }
+
+    var task: Task {
+        return .requestPlain
+    }
+}

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveAPI.swift
@@ -9,27 +9,30 @@ import Moya
 
 enum ArchiveAPI {
     case fetchCourseInfo(routeId: Int)
+    case fetchCourseCategories
 }
 
 extension ArchiveAPI: BaseTargetType {
     var headerType: HeaderType {
         switch self {
-        case .fetchCourseInfo:
+        case .fetchCourseInfo, .fetchCourseCategories:
             return .userHeader(userId: 2)
         }
     }
-
+    
     var path: String {
         switch self {
         case .fetchCourseInfo(let routeId):
             return "routes/\(routeId)/info"
+        case .fetchCourseCategories:
+            return "posts/categories"
         }
     }
-
+    
     var method: Moya.Method {
         return .get
     }
-
+    
     var task: Task {
         return .requestPlain
     }

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
@@ -1,0 +1,22 @@
+//
+//  ArchiveDTO.swift
+//  PAWKEY
+//
+//  Created by 이세민 on 7/15/25.
+//
+
+import Foundation
+
+// Response
+struct ArchiveInfoDTO: Codable {
+    let routeDto: Route
+    let petName: String
+}
+
+struct Route: Codable {
+    let id: Int
+    let locationDescription: String
+    let dateDescription: String
+    let descriptionTags: [String]
+}
+

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
@@ -20,3 +20,17 @@ struct Route: Codable {
     let descriptionTags: [String]
 }
 
+struct CategoryDTO: Codable {
+    let categoryList: [CategoryList]
+}
+
+struct CategoryList: Codable {
+    let categoryId: Int
+    let categoryName: String
+    let categoryOptions: [CategoryOptions]
+}
+
+struct CategoryOptions: Codable {
+    let categoryOptionId: Int
+    let categoryOptionText: String
+}

--- a/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/ArchiveDTO.swift
@@ -34,3 +34,22 @@ struct CategoryOptions: Codable {
     let categoryOptionId: Int
     let categoryOptionText: String
 }
+
+// Request
+struct ArchivePostDTO: Codable {
+    let title: String
+    let description: String
+    let isPublic: Bool
+    let selectedOptionsForCategories: [SelectedCategoryOptions]
+    let routeId: Int
+}
+
+struct SelectedCategoryOptions: Codable {
+    let categoryId: Int
+    let selectedOptionIds: [Int]
+}
+
+// Response
+struct ArchiveResponseDTO: Codable {
+    let postId: Int
+}

--- a/PAWKEY/PAWKEY/Network/Walk/WalkCourseAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Walk/WalkCourseAPI.swift
@@ -9,13 +9,13 @@ import Foundation
 import Moya
 
 enum WalkCourseAPI {
-    case postWalkCourse(userId: Int, body: WalkCourseRequestDTO, image: Data?)
+    case postWalkCourse(body: WalkCourseRequestDTO, image: Data?)
 }
 
 extension WalkCourseAPI: BaseTargetType {
     var headerType: HeaderType {
         switch self {
-        case let .postWalkCourse(userId, _, _):
+        case let .postWalkCourse(_, _):
             return .userHeader(userId: 2)
         }
     }
@@ -36,7 +36,7 @@ extension WalkCourseAPI: BaseTargetType {
     
     var task: Task {
         switch self {
-        case let .postWalkCourse(_, body, image):
+        case let .postWalkCourse(body, image):
             var multipartData: [MultipartFormData] = []
             
             if let jsonData = try? JSONEncoder().encode(body) {
@@ -52,7 +52,7 @@ extension WalkCourseAPI: BaseTargetType {
                     provider: .data(image),
                     name: "trackingImage",
                     fileName: "snapshot.jpg",
-                    mimeType: "image/jpeg"
+                    mimeType: "multipart-form-data"
                 ))
             }
             

--- a/PAWKEY/PAWKEY/Presentation/ActivityArea/ViewModel/ActivityAreaMapViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/ActivityArea/ViewModel/ActivityAreaMapViewModel.swift
@@ -56,7 +56,7 @@ class ActivityAreaMapViewModel: ObservableObject {
     @MainActor
     func updateUserRegion(regionId: Int) async {
         do {
-            try await provider.async.requestPlain(.updateUserRegion(regionId: regionId))
+            try await provider.async.requestPlain(.updateUserRegion)
             print("요청 처리 성공: 지역 변경 성공")
             
             self.isShowToast = true

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
@@ -16,7 +16,7 @@ struct ArchiveView: View {
     
     init(viewModel: ArchiveViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
-    }        
+    }
     
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -98,30 +98,15 @@ struct ArchiveView: View {
                         .padding(.bottom, 23)
                     
                     VStack(alignment: .leading, spacing: 32) {
-                        QuestionForm(
-                            question: "🚸 산책 중 안전 요소는 어땠나요?",
-                            tags: [
-                                "킥보드나 자전거가 거의 없어요",
-                                "차량이 거의 다니지 않아요",
-                                "야간 조명이 잘 되어있어요",
-                                "보도와 차도가 구분되어 있어요",
-                                "보도가 넓어서 산책하기 편했어요"
-                            ],
-                            selectedTags: $viewModel.safetyTags
-                        )
-                        
-                        QuestionForm(
-                            question: "🧺 산책 중 어떤 편의 시설이 있었나요?",
-                            tags: [
-                                "배변 봉투 쓰레기통이 있어요",
-                                "애견 산책로가 있어요",
-                                "쉴 곳이 있어요",
-                                "편의점이 있어요",
-                                "반려견 동반 가능한 카페가 있어요"
-                            ],
-                            selectedTags: $viewModel.facilityTags
-                        )
+                        ForEach(viewModel.categories, id: \.categoryId) { category in
+                            QuestionForm(
+                                question: category.categoryName,
+                                tags: viewModel.categoryOptionTexts(category.categoryId),
+                                selectedTags: viewModel.selectedOptionsBinding(category.categoryId)
+                            )
+                        }
                     }
+                    
                 }
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)
@@ -175,6 +160,7 @@ struct ArchiveView: View {
             
             Task {
                 await viewModel.fetchCourseInfo(routeId: 8)
+                await viewModel.fetchCourseCategories()
             }
         }
         .onChange(of: viewModel.selectedItems) {

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
@@ -159,7 +159,7 @@ struct ArchiveView: View {
             }
             
             Task {
-                await viewModel.fetchCourseInfo(routeId: 8)
+                await viewModel.fetchCourseInfo(routeId: 54)
                 await viewModel.fetchCourseCategories()
             }
         }
@@ -171,15 +171,19 @@ struct ArchiveView: View {
     }
     
     private func pushCourseDetail(isPrivate: Bool) {
-        let courseDetailVM = CourseDetailViewModel()
-        var imagesToSend = viewModel.selectedImages
-        
-        if let snapshot = viewModel.snapshot {
-            imagesToSend.insert(snapshot, at: 0)
+        Task {
+            await viewModel.uploadCourse(isPublic: !isPrivate)
+
+            let courseDetailVM = CourseDetailViewModel()
+            var imagesToSend = viewModel.selectedImages
+            
+            if let snapshot = viewModel.snapshot {
+                imagesToSend.insert(snapshot, at: 0)
+            }
+            
+            courseDetailVM.images = imagesToSend
+            courseDetailVM.isPrivate = isPrivate
+            coordinator.push(.courseDetail(courseDetailVM))
         }
-        
-        courseDetailVM.images = imagesToSend
-        courseDetailVM.isPrivate = isPrivate
-        coordinator.push(.courseDetail(courseDetailVM))
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
@@ -60,15 +60,22 @@ struct ArchiveView: View {
                 .padding([.vertical, .bottom], 12)
                 
                 VStack(alignment: .leading) {
-                    TimePlaceCell(type: .place("강남구 역삼동"))
+                    TimePlaceCell(type: .place(viewModel.location))
                         .padding(.bottom, 4)
                     
-                    TimePlaceCell(type: .time("2025.07.08(화) | 오후 11:28"))
+                    TimePlaceCell(type: .time(viewModel.time))
                         .padding(.bottom, 12)
                     
-                    Chip(title: "옵션")
-                        .padding(.top, 10)
-                        .padding(.bottom, 16)
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(viewModel.descriptionTags, id: \.self) { tag in
+                                Chip(title: tag)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 16)
+                    .padding(.top, 10)
+                    
                 }
                 .padding(.horizontal, 16)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -80,7 +87,7 @@ struct ArchiveView: View {
                     .padding(.bottom, 24)
                 
                 VStack(alignment: .leading) {
-                    Text("포비와의 산책 어땠나요?")
+                    Text("\(viewModel.petName)와의 산책 어땠나요?")
                         .font(.head_18_sb)
                         .foregroundStyle(.pawkeyBlack)
                         .padding(.bottom, 3)
@@ -148,7 +155,7 @@ struct ArchiveView: View {
                     CTAButton(title: "산책 기록 공유하기", isDisabled: !viewModel.isButtonDisabled, buttonStyle: .filled) {
                         pushCourseDetail(isPrivate: false)
                     }
-
+                    
                     CTAButton(title: "산책 기록 나만보기", isDisabled: !viewModel.isButtonDisabled, buttonStyle: .text) {
                         pushCourseDetail(isPrivate: true)
                     }
@@ -164,6 +171,10 @@ struct ArchiveView: View {
         .onAppear {
             withAnimation {
                 mainTabViewModel.isHidden = true
+            }
+            
+            Task {
+                await viewModel.fetchCourseInfo(routeId: 8)
             }
         }
         .onChange(of: viewModel.selectedItems) {

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
@@ -104,3 +104,42 @@ extension ArchiveViewModel {
         )
     }
 }
+
+extension ArchiveViewModel {
+    @MainActor
+    func uploadCourse(isPublic: Bool) async {
+        let selectedCategoryOptions = selectedOptions.map { categoryId, selectedTexts in
+            let optionIds = categories
+                .first(where: { $0.categoryId == categoryId })?
+                .categoryOptions
+                .filter { selectedTexts.contains($0.categoryOptionText) }
+                .map { $0.categoryOptionId } ?? []
+            
+            return SelectedCategoryOptions(categoryId: categoryId, selectedOptionIds: optionIds)
+        }
+        
+        let body = ArchivePostDTO(
+            title: titleText,
+            description: reviewText,
+            isPublic: isPublic,
+            selectedOptionsForCategories: selectedCategoryOptions,
+            routeId: 54
+        )
+        
+        let imageDatas = selectedImages.compactMap { $0.jpegData(compressionQuality: 0.8) }
+        
+        do {
+            let response: BaseDTO<ArchiveResponseDTO> = try await provider.async.request(
+                ArchiveAPI.postCourse(body: body, images: imageDatas)
+            )
+            
+            print("\(response.message)")
+            if let postId = response.data?.postId {
+                print("postId: \(postId)")
+            }
+            
+        } catch {
+            print("업로드 실패: \(error.localizedDescription)")
+        }
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
@@ -10,16 +10,18 @@ import PhotosUI
 import Moya
 
 class ArchiveViewModel: ObservableObject {
+    private let provider = MoyaProvider<ArchiveAPI>()
+    
     @Published var selectedItems: [PhotosPickerItem] = []
     @Published var selectedImages: [UIImage] = []
     
     @Published var location: String = ""
     @Published var time: String = ""
     @Published var petName: String = ""
-    
     @Published var descriptionTags: [String] = []
-    @Published var safetyTags: Set<String> = []
-    @Published var facilityTags: Set<String> = []
+    
+    @Published var categories: [CategoryList] = []
+    @Published var selectedOptions: [Int: Set<String>] = [:]
     
     @Published var titleText: String = ""
     @Published var reviewText: String = ""
@@ -29,11 +31,8 @@ class ArchiveViewModel: ObservableObject {
     var isButtonDisabled: Bool {
         !titleText.trimmingCharacters(in: .whitespaces).isEmpty &&
         !reviewText.trimmingCharacters(in: .whitespaces).isEmpty &&
-        !safetyTags.isEmpty &&
-        !facilityTags.isEmpty
+        selectedOptions.values.allSatisfy { !$0.isEmpty }
     }
-    
-    private let provider = MoyaProvider<ArchiveAPI>().async
     
     @MainActor
     func loadImagesFromPicker() async {
@@ -47,11 +46,13 @@ class ArchiveViewModel: ObservableObject {
         selectedImages.append(contentsOf: newImages)
         selectedItems = []
     }
-    
+}
+
+extension ArchiveViewModel {
     @MainActor
     func fetchCourseInfo(routeId: Int) async {
         do {
-            let response: BaseDTO<ArchiveInfoDTO> = try await provider.request(ArchiveAPI.fetchCourseInfo(routeId: routeId))
+            let response: BaseDTO<ArchiveInfoDTO> = try await provider.async.request(ArchiveAPI.fetchCourseInfo(routeId: routeId))
             if let data = response.data {
                 self.location = data.routeDto.locationDescription
                 self.time = data.routeDto.dateDescription
@@ -70,5 +71,36 @@ class ArchiveViewModel: ObservableObject {
         } catch {
             print("정보 불러오기 실패: \(error)")
         }
+    }
+    
+    @MainActor
+    func fetchCourseCategories() async {
+        do {
+            let response: BaseDTO<CategoryDTO> = try await provider.async.request(ArchiveAPI.fetchCourseCategories)
+            
+            if let data = response.data {
+                self.categories = data.categoryList
+                for category in data.categoryList {
+                    selectedOptions[category.categoryId] = []
+                }
+                
+                print("\(response.message)")
+            }
+        } catch {
+            print("카테고리 불러오기 실패: \(error)")
+        }
+    }
+}
+
+extension ArchiveViewModel {
+    func categoryOptionTexts(_ categoryId: Int) -> [String] {
+        categories.first(where: { $0.categoryId == categoryId })?.categoryOptions.map { $0.categoryOptionText } ?? []
+    }
+    
+    func selectedOptionsBinding(_ categoryId: Int) -> Binding<Set<String>> {
+        Binding(
+            get: { self.selectedOptions[categoryId] ?? [] },
+            set: { self.selectedOptions[categoryId] = $0 }
+        )
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/ArchiveViewModel.swift
@@ -7,11 +7,17 @@
 
 import SwiftUI
 import PhotosUI
+import Moya
 
 class ArchiveViewModel: ObservableObject {
     @Published var selectedItems: [PhotosPickerItem] = []
     @Published var selectedImages: [UIImage] = []
     
+    @Published var location: String = ""
+    @Published var time: String = ""
+    @Published var petName: String = ""
+    
+    @Published var descriptionTags: [String] = []
     @Published var safetyTags: Set<String> = []
     @Published var facilityTags: Set<String> = []
     
@@ -27,6 +33,8 @@ class ArchiveViewModel: ObservableObject {
         !facilityTags.isEmpty
     }
     
+    private let provider = MoyaProvider<ArchiveAPI>().async
+    
     @MainActor
     func loadImagesFromPicker() async {
         var newImages: [UIImage] = []
@@ -36,8 +44,31 @@ class ArchiveViewModel: ObservableObject {
                 newImages.append(uiImage)
             }
         }
-        
         selectedImages.append(contentsOf: newImages)
         selectedItems = []
+    }
+    
+    @MainActor
+    func fetchCourseInfo(routeId: Int) async {
+        do {
+            let response: BaseDTO<ArchiveInfoDTO> = try await provider.request(ArchiveAPI.fetchCourseInfo(routeId: routeId))
+            if let data = response.data {
+                self.location = data.routeDto.locationDescription
+                self.time = data.routeDto.dateDescription
+                self.descriptionTags = data.routeDto.descriptionTags
+                self.petName = data.petName
+                
+                print("\(response.message)")
+                print("""
+                            
+                            위치: \(self.location)
+                            시간: \(self.time)
+                            태그: \(self.descriptionTags.joined(separator: ", "))
+                            강아지 이름: \(self.petName)
+                            """)
+            }
+        } catch {
+            print("정보 불러오기 실패: \(error)")
+        }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/WalkCourseViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/WalkCourseViewModel.swift
@@ -304,7 +304,7 @@ extension WalkCourseViewModel {
         
         do {
             let response: BaseDTO<WalkCourseResponseDTO> = try await provider.async.request(
-                .postWalkCourse(userId: userId, body: body, image: imageData)
+                .postWalkCourse(body: body, image: imageData)
             )
             
             print("\(response.message)")


### PR DESCRIPTION
## 📟 연결된 이슈
closed #116 

## 👷 작업한 내용
- 게시물 등록할 때 쓰이는 리뷰 카테고리를 조회
- 산책 루트 정보 조회 (거리/시간태그//강아지이름)
- 게시글 등록

## ⚠️ 참고 사항
- 키워드 선택 로직이 서버에 빠져있다고 해서 다시 확인해야 합니다
- 네비게이션 연결 필요합니다


## 📸 스크린샷
|    구현 내용    |  15 pro   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/26f0edcb-f0b9-43d4-a6f5-7e3bdfff35e5" width ="200"> |
