### PR TITLE
[Network] #109 필터링 카테고리 옵션 조회 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Global/Component/CheckBox/CheckBoxGroup.swift
+++ b/PAWKEY/PAWKEY/Global/Component/CheckBox/CheckBoxGroup.swift
@@ -14,6 +14,7 @@ struct CheckBoxGroup: View {
     
     var items: [SelecteItem]
     var action: ((SelecteItem) -> Void)?
+    var onTap: (() -> ())?
     
     var body: some View {
         VStack(alignment: .leading) {                      
@@ -35,6 +36,7 @@ struct CheckBoxGroup: View {
             .background(.white)
             .onTapGesture {
                 isExpanded.toggle()
+                onTap?()
             }
             if isExpanded {
                 VStack {

--- a/PAWKEY/PAWKEY/Global/Component/CheckBox/CheckBoxGroup.swift
+++ b/PAWKEY/PAWKEY/Global/Component/CheckBox/CheckBoxGroup.swift
@@ -12,8 +12,8 @@ struct CheckBoxGroup: View {
     
     let title: String
     
-    var items: [CheckItem]
-    var action: ((Int) -> Void)?
+    var items: [SelecteItem]
+    var action: ((SelecteItem) -> Void)?
     
     var body: some View {
         VStack(alignment: .leading) {                      
@@ -39,9 +39,9 @@ struct CheckBoxGroup: View {
             if isExpanded {
                 VStack {
                     ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
-                        CheckBoxCell(title: item.title, isSelected: item.isSelected)
+                        CheckBoxCell(title: item.selectText, isSelected: item.isSelected)
                             .onTapGesture {
-                                action?(offset)
+                                action?(item)
                             }
                     }
                 }

--- a/PAWKEY/PAWKEY/Global/Component/Radio/RadioGroup.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Radio/RadioGroup.swift
@@ -14,6 +14,7 @@ struct RadioGroup: View {
     
     var items: [SelecteItem]
     var action: ((SelecteItem) -> Void)?
+    var onTapGroup: (() -> ())?
     
     var body: some View {
         VStack {
@@ -34,6 +35,7 @@ struct RadioGroup: View {
             .padding(.horizontal, 16)
             .onTapGesture {
                 isExpanded.toggle()
+                onTapGroup?()
             }
             if isExpanded {
                 VStack {

--- a/PAWKEY/PAWKEY/Global/Component/Radio/RadioGroup.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Radio/RadioGroup.swift
@@ -12,8 +12,8 @@ struct RadioGroup: View {
     
     let title: String
     
-    var items: [CheckItem]
-    var action: ((Int) -> Void)?
+    var items: [SelecteItem]
+    var action: ((SelecteItem) -> Void)?
     
     var body: some View {
         VStack {
@@ -22,7 +22,7 @@ struct RadioGroup: View {
                     .font(.body_16_sb)
                 Spacer()
                 if let selectedItem = items.filter({$0.isSelected}).first {
-                    Text(selectedItem.title)
+                    Text(selectedItem.selectText)
                         .font(.caption_12_sb)
                         .foregroundStyle(.green)
                 }
@@ -31,24 +31,24 @@ struct RadioGroup: View {
             }
             .background(.white)
             .frame(height: 64)
+            .padding(.horizontal, 16)
             .onTapGesture {
                 isExpanded.toggle()
             }
             if isExpanded {
                 VStack {
                     ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
-                        RadioCell(checkOption: item)
+                        RadioCell(checkOption: .init(title: item.selectText, isSelected: item.isSelected))
                             .onTapGesture {
-                                action?(offset)
+                                action?(item)
                             }
                     }
                 }
+                .padding(.horizontal, 16)
             }
             Divider()
                 .animation(nil)
         }
         .animation(isExpanded ? .easeInOut(duration: 0.2) : nil)
-        .padding(.horizontal, 16)
-        
     }
 }

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterAPI.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterAPI.swift
@@ -1,0 +1,44 @@
+//
+//  FilterAPI.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+import Moya
+
+enum FilterAPI {
+    case fetchFilterOptions
+}
+
+extension FilterAPI: BaseTargetType {
+    var headerType: HeaderType {
+        switch self {
+        case .fetchFilterOptions:
+            return .userHeader(userId: 2)
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchFilterOptions:
+            return "posts/filter"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchFilterOptions:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .fetchFilterOptions:
+            return .requestPlain
+        }
+    }
+}

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterDTO.swift
@@ -5,29 +5,35 @@
 //  Created by 권석기 on 7/16/25.
 //
 
-struct FilterDTO {
+import Foundation
+
+struct FilterDTO: Codable {
     let selectList: [SelectListDTO]
     let categoryList: [CategoryListDTO]
 }
 
-struct SelectListDTO {
+struct SelectListDTO: Codable {
     let selectId: Int
     let selectName: String
-    let options: [SelecteItemDTO]
+    let options: [SelectItemDTO]
 }
 
-struct SelecteItemDTO {
+struct SelectItemDTO: Codable {
     let selectOptionId: Int
     let selectText: String
 }
 
-struct CategoryListDTO {
+struct CategoryListDTO: Codable {
     let categoryId: Int
     let categoryName: String
-    let options: [SelecteItemDTO]
+    let categoryDescription: String
+    let options: [CategoryItemDTO]
 }
 
-struct CategoryItemDTO {
+struct CategoryItemDTO: Codable {
     let categoryOptionId: Int
     let optionText: String
 }
+
+
+

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterDTO.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterDTO.swift
@@ -1,0 +1,33 @@
+//
+//  FilterDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+struct FilterDTO {
+    let selectList: [SelectListDTO]
+    let categoryList: [CategoryListDTO]
+}
+
+struct SelectListDTO {
+    let selectId: Int
+    let selectName: String
+    let options: [SelecteItemDTO]
+}
+
+struct SelecteItemDTO {
+    let selectOptionId: Int
+    let selectText: String
+}
+
+struct CategoryListDTO {
+    let categoryId: Int
+    let categoryName: String
+    let options: [SelecteItemDTO]
+}
+
+struct CategoryItemDTO {
+    let categoryOptionId: Int
+    let optionText: String
+}

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
@@ -8,28 +8,47 @@
 import Foundation
 
 extension Array where Element == SelectListDTO {
-    func toEntity() -> [SelecteList] {
-        map {
-            SelecteList(
-                selectId: $0.selectId,
-                selectName: $0.selectName,
-                options: $0.toEntity().options
+    func toEntity(startingId: Int = 1) -> [SelecteList] {
+        var currentId = startingId
+        return self.map { dto in
+            let newOptions = dto.options.enumerated().map { idx, opt in
+                SelecteItem(
+                    selectOptionId: currentId * 100 + idx,
+                    selectText: opt.selectText,
+                    isSelected: false
+                )
+            }
+            defer { currentId += 1 }
+            return SelecteList(
+                selectId: currentId,
+                selectName: dto.selectName,
+                options: newOptions
             )
         }
     }
 }
 
 extension Array where Element == CategoryListDTO {
-    func toEntity() -> [SelecteList] {
-        map {
-            SelecteList(
-                selectId: $0.categoryId,
-                selectName: $0.categoryName,
-                options: $0.toEntity().options
+    func toEntity(startingId: Int = 100) -> [SelecteList] {
+        var currentId = startingId
+        return self.map { dto in
+            let newOptions = dto.options.enumerated().map { idx, opt in
+                SelecteItem(
+                    selectOptionId: currentId * 100 + idx,
+                    selectText: opt.optionText,
+                    isSelected: false
+                )
+            }
+            defer { currentId += 1 }
+            return SelecteList(
+                selectId: currentId,
+                selectName: dto.categoryName,
+                options: newOptions
             )
         }
     }
 }
+
 
 extension SelectListDTO {
     func toEntity() -> SelecteList {

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
@@ -8,42 +8,24 @@
 import Foundation
 
 extension Array where Element == SelectListDTO {
-    func toEntity(startingId: Int = 1) -> [SelecteList] {
-        var currentId = startingId
-        return self.map { dto in
-            let newOptions = dto.options.enumerated().map { idx, opt in
-                SelecteItem(
-                    selectOptionId: currentId * 100 + idx,
-                    selectText: opt.selectText,
-                    isSelected: false
-                )
-            }
-            defer { currentId += 1 }
-            return SelecteList(
-                selectId: currentId,
-                selectName: dto.selectName,
-                options: newOptions
+    func toEntity() -> [SelectList] {
+        map {
+            SelectList(
+                selectId: $0.selectId,
+                selectName: $0.selectName,
+                options: $0.options.toEntity()
             )
         }
     }
 }
 
 extension Array where Element == CategoryListDTO {
-    func toEntity(startingId: Int = 100) -> [SelecteList] {
-        var currentId = startingId
-        return self.map { dto in
-            let newOptions = dto.options.enumerated().map { idx, opt in
-                SelecteItem(
-                    selectOptionId: currentId * 100 + idx,
-                    selectText: opt.optionText,
-                    isSelected: false
-                )
-            }
-            defer { currentId += 1 }
-            return SelecteList(
-                selectId: currentId,
-                selectName: dto.categoryName,
-                options: newOptions
+    func toEntity() -> [SelectList] {
+        map {
+            SelectList(
+                selectId: $0.categoryId,
+                selectName: $0.categoryName,
+                options: $0.options.toEntity()
             )
         }
     }
@@ -51,8 +33,8 @@ extension Array where Element == CategoryListDTO {
 
 
 extension SelectListDTO {
-    func toEntity() -> SelecteList {
-        SelecteList(
+    func toEntity() -> SelectList {
+        SelectList(
             selectId: selectId,
             selectName: selectName,
             options: options.toEntity()
@@ -72,8 +54,8 @@ extension Array where Element == SelectItemDTO {
 }
 
 extension CategoryListDTO {
-    func toEntity() -> SelecteList {
-        SelecteList(
+    func toEntity() -> SelectList {
+        SelectList(
             selectId: categoryId,
             selectName: categoryName,
             options: options.toEntity()

--- a/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/Filtering/FilterDataMapper.swift
@@ -1,0 +1,74 @@
+//
+//  FilterDataMapper.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+extension Array where Element == SelectListDTO {
+    func toEntity() -> [SelecteList] {
+        map {
+            SelecteList(
+                selectId: $0.selectId,
+                selectName: $0.selectName,
+                options: $0.toEntity().options
+            )
+        }
+    }
+}
+
+extension Array where Element == CategoryListDTO {
+    func toEntity() -> [SelecteList] {
+        map {
+            SelecteList(
+                selectId: $0.categoryId,
+                selectName: $0.categoryName,
+                options: $0.toEntity().options
+            )
+        }
+    }
+}
+
+extension SelectListDTO {
+    func toEntity() -> SelecteList {
+        SelecteList(
+            selectId: selectId,
+            selectName: selectName,
+            options: options.toEntity()
+        )
+    }
+}
+
+extension Array where Element == SelectItemDTO {
+    func toEntity() -> [SelecteItem] {
+        map {
+            SelecteItem(
+                selectOptionId: $0.selectOptionId,
+                selectText: $0.selectText
+            )
+        }
+    }
+}
+
+extension CategoryListDTO {
+    func toEntity() -> SelecteList {
+        SelecteList(
+            selectId: categoryId,
+            selectName: categoryName,
+            options: options.toEntity()
+        )
+    }
+}
+
+extension Array where Element == CategoryItemDTO {
+    func toEntity() -> [SelecteItem] {
+        map {
+            SelecteItem(
+                selectOptionId: $0.categoryOptionId,
+                selectText: $0.optionText
+            )
+        }
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/Model/Filter.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/Model/Filter.swift
@@ -1,0 +1,25 @@
+//
+//  Filter.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct FilterList {
+    var selecteList: [SelecteList] = []
+    var categoryList: [SelecteList] = []
+}
+
+struct SelecteList: Hashable {
+    let selectId: Int
+    let selectName: String
+    var options: [SelecteItem]
+}
+
+struct SelecteItem: Hashable {
+    let selectOptionId: Int
+    let selectText: String
+    var isSelected: Bool = false
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/Model/Filter.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/Model/Filter.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 struct FilterList {
-    var selecteList: [SelecteList] = []
-    var categoryList: [SelecteList] = []
+    var selecteList: [SelectList] = []
+    var categoryList: [SelectList] = []
 }
 
-struct SelecteList: Hashable {
+struct SelectList: Hashable {
     let selectId: Int
     let selectName: String
     var options: [SelecteItem]

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
@@ -36,8 +36,10 @@ struct FilterBottomSheet: View {
                             ),
                             title: selectedList.selectName,
                             items: selectedList.options
-                        ) { selected in
+                        ) { selected in                            
                             viewModel.selectSingleItem(selected)
+                        } onTapGroup: {
+                            viewModel.onTapSingleItemGroup(selectId: selectedList.selectId)
                         }
                     }
                     
@@ -49,7 +51,7 @@ struct FilterBottomSheet: View {
                         .padding(.leading, 16)
                         .animation(nil)
                     
-                    ForEach(viewModel.filterItemList.categoryList   , id: \.self) { selectedList in
+                    ForEach(viewModel.filterItemList.categoryList ,id: \.self) { selectedList in
                         CheckBoxGroup(
                             isExpanded: Binding(
                                 get: { viewModel.mutipleItemexpandedGroup[selectedList.selectId] ?? false },
@@ -59,6 +61,8 @@ struct FilterBottomSheet: View {
                             items: selectedList.options
                         ) { selected in
                             viewModel.selectMultipleItem(selected)
+                        } onTap: {
+                            viewModel.onTapMutipleItemGroup(selectId: selectedList.selectId)
                         }
                     }
                 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
@@ -12,43 +12,15 @@ struct FilterBottomSheet: View {
     
     var body: some View {
         VStack {
-            ScrollView {
+            ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading) {
                     Spacer().frame(height: 28)
                     Text("산책 경로 옵션")
                         .font(.head_20_b)
                         .padding(.leading, 16)
-                    Spacer().frame(height: 36)
-                    Text("복수 선택 옵션")
-                        .font(.caption_12_sb)
-                        .foregroundStyle(.green500)
-                        .frame(maxWidth: .infinity, maxHeight: 30, alignment: .leading)
-                        .padding(.leading, 16)
-                        .animation(nil)
-                    CheckBoxGroup(
-                        isExpanded: $viewModel.isExpandWalkingTime,
-                        title: "산책 시간",
-                        items: viewModel.walkingTimeList
-                    ) { itemIndex in
-                        viewModel.selectWalkRouteOption(.walkingTime(index: itemIndex))
-                    }
-                    CheckBoxGroup(
-                        isExpanded: $viewModel.isExpandSafety,
-                        title: "안전",
-                        items: viewModel.safetyList
-                    ) { itemIndex in
-                        viewModel.selectWalkRouteOption(.safety(index: itemIndex))
-                    }
-                    
-                    CheckBoxGroup(
-                        isExpanded: $viewModel.isExpandConvenience,
-                        title: "편리성 관련",
-                        items: viewModel.convenienceList
-                    ) { itemIndex in
-                        viewModel.selectWalkRouteOption(.convenience(index: itemIndex))
-                    }
                     
                     Spacer().frame(height: 36)
+                    
                     Text("단일 선택 옵션")
                         .font(.caption_12_sb)
                         .foregroundStyle(.green500)
@@ -56,41 +28,62 @@ struct FilterBottomSheet: View {
                         .padding(.leading, 16)
                         .animation(nil)
                     
-                    RadioGroup(
-                        isExpanded: $viewModel.isExpandEnvironment,
-                        title: "환경 관련",
-                        items: viewModel.environmentList
-                    ) { itemIndex in
-                        viewModel.selectWalkRouteOption(.environment(index: itemIndex))
+                    ForEach(viewModel.filterItemList.selecteList, id: \.self) { selectedList in
+                        RadioGroup(
+                            isExpanded: Binding(
+                                get: { viewModel.expandedGroup[selectedList.selectId] ?? false },
+                                set: { viewModel.expandedGroup[selectedList.selectId] = $0 }
+                            ),
+                            title: selectedList.selectName,
+                            items: selectedList.options
+                        ) { selectedItem in
+                            print(selectedItem)
+                        }
                     }
                     
-                    RadioGroup(
-                        isExpanded: $viewModel.isExpandMood,
-                        title: "분위기",
-                        items: viewModel.moodList
-                    ) { itemIndex in
-                        viewModel.selectWalkRouteOption(.mood(index: itemIndex))
+                    Spacer().frame(height: 36)
+                    Text("복수 선택 옵션")
+                        .font(.caption_12_sb)
+                        .foregroundStyle(.green500)
+                        .frame(maxWidth: .infinity, maxHeight: 30, alignment: .leading)
+                        .padding(.leading, 16)
+                        .animation(nil)
+                    
+                    ForEach(viewModel.filterItemList.categoryList   , id: \.self) { selectedList in
+                        CheckBoxGroup(
+                            isExpanded: Binding(
+                                get: { viewModel.expandedGroup[selectedList.selectId] ?? false },
+                                set: { viewModel.expandedGroup[selectedList.selectId] = $0 }
+                            ),
+                            title: selectedList.selectName,
+                            items: selectedList.options
+                        ) { selectedItem in
+                            print(selectedItem)
+                        }
                     }
                 }
             }
-            HStack {
-                CTAButton(title: "옵션 적용하기") {
-                    viewModel.isShowSheet = false
-                }
-                Button {
-                    viewModel.resetAllOptions()
-                } label: {
-                    VStack {
-                        Image(.rotateIcon)
-                    }
-                    .frame(maxWidth: 56, minHeight: 56)
-                }
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(.gray50)
-                )
+        }
+        HStack {
+            CTAButton(title: "옵션 적용하기") {
+                viewModel.isShowSheet = false
             }
-            .padding(.horizontal, 16)
+            Button {
+                viewModel.resetAllOptions()
+            } label: {
+                VStack {
+                    Image(.rotateIcon)
+                }
+                .frame(maxWidth: 56, minHeight: 56)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.gray50)
+            )
+        }
+        .padding(.horizontal, 16)
+        .task {
+            await viewModel.fetchFilterOptions()
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/FilterBottomSheet.swift
@@ -31,13 +31,13 @@ struct FilterBottomSheet: View {
                     ForEach(viewModel.filterItemList.selecteList, id: \.self) { selectedList in
                         RadioGroup(
                             isExpanded: Binding(
-                                get: { viewModel.expandedGroup[selectedList.selectId] ?? false },
-                                set: { viewModel.expandedGroup[selectedList.selectId] = $0 }
+                                get: { viewModel.singleItemexpandedGroup[selectedList.selectId] ?? false },
+                                set: { viewModel.singleItemexpandedGroup[selectedList.selectId] = $0 }
                             ),
                             title: selectedList.selectName,
                             items: selectedList.options
-                        ) { selectedItem in
-                            print(selectedItem)
+                        ) { selected in
+                            viewModel.selectSingleItem(selected)
                         }
                     }
                     
@@ -52,13 +52,13 @@ struct FilterBottomSheet: View {
                     ForEach(viewModel.filterItemList.categoryList   , id: \.self) { selectedList in
                         CheckBoxGroup(
                             isExpanded: Binding(
-                                get: { viewModel.expandedGroup[selectedList.selectId] ?? false },
-                                set: { viewModel.expandedGroup[selectedList.selectId] = $0 }
+                                get: { viewModel.mutipleItemexpandedGroup[selectedList.selectId] ?? false },
+                                set: { viewModel.mutipleItemexpandedGroup[selectedList.selectId] = $0 }
                             ),
                             title: selectedList.selectName,
                             items: selectedList.options
-                        ) { selectedItem in
-                            print(selectedItem)
+                        ) { selected in
+                            viewModel.selectMultipleItem(selected)
                         }
                     }
                 }
@@ -66,7 +66,7 @@ struct FilterBottomSheet: View {
         }
         HStack {
             CTAButton(title: "옵션 적용하기") {
-                viewModel.isShowSheet = false
+                viewModel.saveFilterOption()
             }
             Button {
                 viewModel.resetAllOptions()
@@ -82,8 +82,5 @@ struct FilterBottomSheet: View {
             )
         }
         .padding(.horizontal, 16)
-        .task {
-            await viewModel.fetchFilterOptions()
-        }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -110,7 +110,22 @@ struct MapAndListView: View {
                                 }
                                 .overlay(Image(.settingGray))
                         }
-                        Spacer()                     
+                        Spacer()
+                        if mapAndListViewModel.selectedFilterItem.isEmpty {
+                            HStack {
+                                FilterChip(title: "")
+                                Spacer()
+                            }
+                        } else {
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack {
+                                    ForEach(mapAndListViewModel.selectedFilterItem, id: \.self) {
+                                        FilterChip(title: $0.selectText)
+                                    }
+                                }
+                                .padding(.vertical, 1)
+                            }
+                        }
                     }
                     .padding(.horizontal, 16)
                     
@@ -138,6 +153,9 @@ struct MapAndListView: View {
         }
         .onAppear {
             viewModel.requestPermission()
+        }
+        .task {
+            await mapAndListViewModel.fetchFilterOptions()
         }
         .fullScreenCover(isPresented: $showWalkCourseView) {
             WalkCourseView(viewModel: viewModel, showWalkCourseView: $showWalkCourseView) { distance, elapsedTime, stepCount, snapshot in

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -184,11 +184,10 @@ struct TabButton: View {
     
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 4) {
+            VStack(spacing: 10) {
                 Text(title)
                     .font(.head_22_b)
                     .foregroundColor(isSelected ? .pawkeyBlack : .gray200)
-                    .padding(10)
                 
                 if isSelected {
                     Rectangle()

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -110,21 +110,7 @@ struct MapAndListView: View {
                                 }
                                 .overlay(Image(.settingGray))
                         }
-                        Spacer()
-                        if mapAndListViewModel.selectedOptions.isEmpty {
-                            HStack {
-                                FilterChip(title: "")
-                                Spacer()
-                            }
-                        } else {
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack {
-                                    ForEach(mapAndListViewModel.selectedOptions, id: \.self.id) {
-                                        FilterChip(title: $0.title)
-                                    }
-                                }
-                            }
-                        }
+                        Spacer()                     
                     }
                     .padding(.horizontal, 16)
                     

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Moya
+
 final class MapAndListViewModel: ObservableObject {
     
     enum WalkRouteOption {
@@ -18,81 +20,12 @@ final class MapAndListViewModel: ObservableObject {
     }
     
     @Published var isShowSheet = false
-    @Published var isExpandWalkingTime = false
-    @Published var isExpandSafety = false
-    @Published var isExpandConvenience = false
-    @Published var isExpandEnvironment = false
-    @Published var isExpandMood = false
-    
-    @Published var walkingTimeList: [CheckItem] = [
-        .init(title: "20분 이내", isSelected: false),
-        .init(title: "21~40분", isSelected: false),
-        .init(title: "41~60분", isSelected: false),
-        .init(title: "1시간 넘게", isSelected: false),
-    ]
-    
-    @Published var safetyList: [CheckItem] = [
-        .init(title: "킥보드/자전거 거의 없음", isSelected: false),
-        .init(title: "차량 거의 없음", isSelected: false),
-        .init(title: "야간에도 밝음", isSelected: false),
-        .init(title: "보도/차도 구분됨", isSelected: false),
-        .init(title: "넓은 보도", isSelected: false),
-    ]
-    
-    @Published var convenienceList: [CheckItem] = [
-        .init(title: "배변 봉투 쓰레기통", isSelected: false),
-        .init(title: "벤치", isSelected: false),
-        .init(title: "편의점", isSelected: false),
-        .init(title: "반려견 동반 카페", isSelected: false),
-    ]
-    
-    @Published var environmentList: [CheckItem] = [
-        .init(title: "풀 많은 길 위주", isSelected: false),
-        .init(title: "흙길 위주", isSelected: false),
-        .init(title: "아스팔트/벽돌길 위주", isSelected: false),
-        .init(title: "뛰어놀 공간", isSelected: false),
-    ]
-    
-    @Published var moodList: [CheckItem] = [
-        .init(title: "조용한 분위기", isSelected: false),
-        .init(title: "적당한 유동인구", isSelected: false),
-        .init(title: "유동 인구 많음", isSelected: false),
-    ]
-    
-    var selectedOptions: [CheckItem] {
-        return walkingTimeList.filter { $0.isSelected } +
-        safetyList.filter { $0.isSelected } +
-        convenienceList.filter { $0.isSelected } +
-        environmentList.filter { $0.isSelected } +
-        moodList.filter { $0.isSelected }
-    }
-    
-    func selectWalkRouteOption(_ option: WalkRouteOption) {
-        switch option {
-        case .walkingTime(let index):
-            walkingTimeList = selecteMultipleOption(at: index, from: walkingTimeList)
-        case .safety(let index):
-            safetyList = selecteMultipleOption(at: index, from: safetyList)
-        case .convenience(let index):
-            convenienceList = selecteMultipleOption(at: index, from: convenienceList)
-        case .environment(let index):
-            environmentList = selecteSingleOption(at: index, from: environmentList)
-        case .mood(let index):
-            moodList = selecteSingleOption(at: index, from: moodList)
-        }
-    }
+    @Published var filterItemList = FilterList()
+    @Published var expandedGroup: [Int: Bool] = [:]
+    @Published var selectedFilterItem: [SelecteItem] = []
     
     func resetAllOptions() {
-        walkingTimeList = walkingTimeList.map { .init(title: $0.title, isSelected: false)}
-        safetyList = safetyList.map { .init(title: $0.title, isSelected: false)}
-        convenienceList = convenienceList.map { .init(title: $0.title, isSelected: false)}
-        environmentList = environmentList.map { .init(title: $0.title, isSelected: false)}
-        moodList = moodList.map { .init(title: $0.title, isSelected: false)}
-        isExpandWalkingTime = false
-        isExpandSafety = false
-        isExpandConvenience = false
-        isExpandEnvironment = false
-        isExpandMood = false
+     
     }
     
     private func selecteSingleOption(at index: Int, from list: [CheckItem]) -> [CheckItem] {
@@ -112,5 +45,30 @@ final class MapAndListViewModel: ObservableObject {
         var newList = list
         newList[index].isSelected.toggle()
         return newList
+    }
+}
+
+// MARK: - API
+
+extension MapAndListViewModel {
+    
+    @MainActor
+    func fetchFilterOptions() async {
+        let provider = MoyaProvider<FilterAPI>(plugins: [MoyaLoggingPlugin()])
+        do {
+            let response: BaseDTO<FilterDTO> = try await provider.async.request(.fetchFilterOptions)
+            
+            guard let data = response.data else {
+                return
+            }
+            
+            let selectList = data.selectList.toEntity()
+            let categoryList = data.categoryList.toEntity()
+            
+            filterItemList.selecteList = selectList + Array(categoryList.prefix(2))
+            filterItemList.categoryList = Array(categoryList.dropFirst(2))
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
@@ -11,40 +11,96 @@ import Moya
 
 final class MapAndListViewModel: ObservableObject {
     
-    enum WalkRouteOption {
-        case walkingTime(index: Int)
-        case safety(index: Int)
-        case convenience(index: Int)
-        case environment(index: Int)
-        case mood(index: Int)
-    }
+    private let provider = MoyaProvider<FilterAPI>(plugins: [MoyaLoggingPlugin()])
     
     @Published var isShowSheet = false
+    @Published var filterItem = FilterList()
     @Published var filterItemList = FilterList()
-    @Published var expandedGroup: [Int: Bool] = [:]
+    @Published var singleItemexpandedGroup: [Int: Bool] = [:] {
+        didSet {
+            print(singleItemexpandedGroup)
+        }
+    }
+    @Published var mutipleItemexpandedGroup: [Int: Bool] = [:]
+    @Published var addedFilterItem: [SelecteItem] = []
     @Published var selectedFilterItem: [SelecteItem] = []
     
     func resetAllOptions() {
-     
-    }
-    
-    private func selecteSingleOption(at index: Int, from list: [CheckItem]) -> [CheckItem] {
-        var newList = list
+        singleItemexpandedGroup = singleItemexpandedGroup.mapValues { _ in false }
+        mutipleItemexpandedGroup = singleItemexpandedGroup.mapValues { _ in false }
         
-        if let firstIndex = list.firstIndex(where: {$0.isSelected}) {
-            newList[firstIndex].isSelected = false
-            newList[index].isSelected = true            
-        } else {
-            newList[index].isSelected = true
+        filterItemList.selecteList = filterItemList.selecteList.map { group in
+            var g = group
+            g.options = g.options.map {
+                SelecteItem(selectOptionId: $0.selectOptionId, selectText: $0.selectText, isSelected: false)
+            }
+            return g
         }
         
-        return newList
+        filterItemList.categoryList = filterItemList.categoryList.map { group in
+            var g = group
+            g.options = g.options.map {
+                SelecteItem(selectOptionId: $0.selectOptionId, selectText: $0.selectText, isSelected: false)
+            }
+            return g
+        }
+
+        addedFilterItem = []
+        selectedFilterItem = []
     }
     
-    private func selecteMultipleOption(at index: Int, from list: [CheckItem]) -> [CheckItem] {
-        var newList = list
-        newList[index].isSelected.toggle()
-        return newList
+    func selectSingleItem(_ selected: SelecteItem) {
+        guard let groupIndex = filterItemList.selecteList.firstIndex(where: {
+            $0.options.contains(where: { $0.selectOptionId == selected.selectOptionId })
+        }) else { return }
+        
+        var group = filterItemList.selecteList[groupIndex]
+        group.options = group.options.map {
+            SelecteItem(
+                selectOptionId: $0.selectOptionId,
+                selectText: $0.selectText,
+                isSelected: $0.selectOptionId == selected.selectOptionId
+            )
+        }
+
+        filterItemList.selecteList[groupIndex] = group
+        
+        addedFilterItem.removeAll {
+            group.options.map(\.selectOptionId).contains($0.selectOptionId)
+        }
+        addedFilterItem.append(selected)
+    }
+
+    
+    func selectMultipleItem(_ selected: SelecteItem) {
+        guard let groupIndex = filterItemList.categoryList.firstIndex(where: {
+            $0.options.contains(where: { $0.selectOptionId == selected.selectOptionId })
+        }) else { return }
+
+        var group = filterItemList.categoryList[groupIndex]
+        group.options = group.options.map {
+            if $0.selectOptionId == selected.selectOptionId {
+                return SelecteItem(
+                    selectOptionId: $0.selectOptionId,
+                    selectText: $0.selectText,
+                    isSelected: !$0.isSelected
+                )
+            }
+            return $0
+        }
+
+        filterItemList.categoryList[groupIndex] = group
+
+        if let index = addedFilterItem.firstIndex(where: { $0.selectOptionId == selected.selectOptionId }) {
+            addedFilterItem.remove(at: index)
+        } else {
+            addedFilterItem.append(selected)
+        }
+    }
+    
+    func saveFilterOption() {
+        selectedFilterItem = addedFilterItem
+        isShowSheet = false
     }
 }
 
@@ -54,7 +110,7 @@ extension MapAndListViewModel {
     
     @MainActor
     func fetchFilterOptions() async {
-        let provider = MoyaProvider<FilterAPI>(plugins: [MoyaLoggingPlugin()])
+        
         do {
             let response: BaseDTO<FilterDTO> = try await provider.async.request(.fetchFilterOptions)
             
@@ -66,7 +122,9 @@ extension MapAndListViewModel {
             let categoryList = data.categoryList.toEntity()
             
             filterItemList.selecteList = selectList + Array(categoryList.prefix(2))
-            filterItemList.categoryList = Array(categoryList.dropFirst(2))
+            filterItemList.categoryList = Array(categoryList.dropFirst(2))            
+            filterItem.selecteList = selectList + Array(categoryList.prefix(2))
+            filterItem.categoryList = Array(categoryList.dropFirst(2))
         } catch {
             print(error.localizedDescription)
         }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
@@ -16,11 +16,7 @@ final class MapAndListViewModel: ObservableObject {
     @Published var isShowSheet = false
     @Published var filterItem = FilterList()
     @Published var filterItemList = FilterList()
-    @Published var singleItemexpandedGroup: [Int: Bool] = [:] {
-        didSet {
-            print(singleItemexpandedGroup)
-        }
-    }
+    @Published var singleItemexpandedGroup: [Int: Bool] = [:]
     @Published var mutipleItemexpandedGroup: [Int: Bool] = [:]
     @Published var addedFilterItem: [SelecteItem] = []
     @Published var selectedFilterItem: [SelecteItem] = []
@@ -70,7 +66,6 @@ final class MapAndListViewModel: ObservableObject {
         }
         addedFilterItem.append(selected)
     }
-
     
     func selectMultipleItem(_ selected: SelecteItem) {
         guard let groupIndex = filterItemList.categoryList.firstIndex(where: {
@@ -101,6 +96,16 @@ final class MapAndListViewModel: ObservableObject {
     func saveFilterOption() {
         selectedFilterItem = addedFilterItem
         isShowSheet = false
+    }
+    
+    func onTapSingleItemGroup(selectId: Int) {
+        singleItemexpandedGroup = singleItemexpandedGroup.mapValues { _ in false }
+        singleItemexpandedGroup.updateValue(true, forKey: selectId)
+    }
+    
+    func onTapMutipleItemGroup(selectId: Int) {
+        mutipleItemexpandedGroup = mutipleItemexpandedGroup.mapValues { _ in false }
+        mutipleItemexpandedGroup.updateValue(true, forKey: selectId)
     }
 }
 

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -186,7 +186,6 @@ extension ProfileSetUpViewModel {
                 errorMessage = "에러 발생: 데이터를 찾을 수 없음"
                 return
             }
-            print(data)
         } catch {
             errorMessage = "에러 발생: \(error.localizedDescription)"
         }

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 import Moya
 
-
-
 final class ProfileSetUpViewModel: ObservableObject {
         
     enum ProfileStep: Int {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #109 

## 👷 작업한 내용
- 필터링 카테고리 옵션 조회 API 연동
- 카테고리 옵션 조회에 필요한 API, DTO 객체 추가
- 필터링 관련 컴포넌트 수정
- 상단탭 underline을 텍스트 넒이에 맞췄습니다
- 필터링 태그 상하단 잘림 현상 수정

## ⚠️ 참고 사항
-  서버에서 내려주는 필터링 관련 id가 게시물 조회에서도 쓰이는 것 같던데 순서대로 뿌려주기 위해서 클라이언트에서 다시 채번했습니다 오후중에 서버에게 다시 물어봐서 조정 하겠습니다

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "https://github.com/user-attachments/assets/12ce9298-8095-4134-9436-b3c92179437d" width = "200"> |
