### PR TITLE
[Network] #108 산책 게시물 리스트 조회 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Global/Component/Common/ReviewCard.swift
+++ b/PAWKEY/PAWKEY/Global/Component/Common/ReviewCard.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct ReviewCard: View {
     
     enum CardType {
@@ -39,8 +41,9 @@ struct ReviewCard: View {
         
         VStack(spacing: 0) {
             ZStack(alignment: .bottom) {
-                Image(walkRouteImg)
+                KFImage(URL(string: walkRouteImg))
                     .resizable()
+                    .frame(minHeight: 240, maxHeight: 240)
                     .aspectRatio(contentMode: .fit)
                     .overlay(
                         // 그라데이션 오버레이
@@ -54,7 +57,7 @@ struct ReviewCard: View {
                 // 상단 프로필
                 HStack {
                     // 반려견 사진
-                    Image(profileImg)
+                    KFImage(URL(string: profileImg))
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .frame(width: 43, height: 43)

--- a/PAWKEY/PAWKEY/Global/Extension/String+.swift
+++ b/PAWKEY/PAWKEY/Global/Extension/String+.swift
@@ -1,0 +1,26 @@
+//
+//  String+.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+extension String {
+    func toFormattedDateString() -> String? {
+        let inputFormatter = DateFormatter()
+        inputFormatter.locale = Locale(identifier: "en_US_POSIX")
+        inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+
+        guard let date = inputFormatter.date(from: self) else {
+            return nil
+        }
+
+        let outputFormatter = DateFormatter()
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        outputFormatter.dateFormat = "yyyy/MM/dd"
+
+        return outputFormatter.string(from: date)
+    }
+}

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
@@ -1,0 +1,55 @@
+//
+//  WalkPostAPI.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+import Moya
+
+enum WalkPostAPI {
+    case fetchPosts
+}
+
+extension WalkPostAPI: BaseTargetType {
+    var headerType: HeaderType {
+        switch self {
+        case .fetchPosts:
+            return .userHeader(userId: 2)
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchPosts:
+            return "posts/filter"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchPosts:
+            return .post
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .fetchPosts:
+            let dummy = FilterRequest(
+                durationStart: nil,
+                durationEnd: nil,
+                selectedOptions: [
+                    .init(
+                        categoryId: nil,
+                        optionsIds: nil
+                    )
+                ]
+            )
+            return .requestJSONEncodable(dummy)
+        }
+    }
+}
+

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
@@ -1,0 +1,35 @@
+//
+//  WalkPostDataMapper.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+
+extension Array where Element == PostDTO {
+    func toEntity() -> [WalkPost] {
+        map {
+            WalkPost(
+                postId: $0.postId,
+                createdAt: $0.createdAt,
+                isLike: $0.isLike,
+                title: $0.title,
+                routeId: $0.routeId,
+                representativeImageUrl: $0.representativeImageUrl,
+                writer: $0.writer.toEntity(),
+                descriptionTags: $0.descriptionTags
+            )
+        }
+    }
+}
+
+extension WriterDTO {
+    func toEntity() -> PostWriter {
+        PostWriter(
+            userId: userId,
+            petName: petName,
+            petProfileImageUrl: petProfileImageUrl
+        )
+    }
+}
+

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
@@ -5,13 +5,14 @@
 //  Created by 권석기 on 7/16/25.
 //
 
+import Foundation
 
 extension Array where Element == PostDTO {
     func toEntity() -> [WalkPost] {
         map {
             WalkPost(
                 postId: $0.postId,
-                createdAt: $0.createdAt,
+                createdAt: $0.createdAt.toFormattedDateString() ?? "",
                 isLike: $0.isLike,
                 title: $0.title,
                 routeId: $0.routeId,
@@ -32,4 +33,3 @@ extension WriterDTO {
         )
     }
 }
-

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostRequestDTO.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostRequestDTO.swift
@@ -1,0 +1,20 @@
+//
+//  WalkPostRequestDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct FilterRequest: Codable {
+    var durationStart: String?
+    var durationEnd: String?
+    var selectedOptions: [SelectedOption]
+}
+
+struct SelectedOption: Codable {
+    var categoryId: Int?
+    var optionsIds: [Int]?
+}
+

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostResponseDTO.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostResponseDTO.swift
@@ -1,0 +1,29 @@
+//
+//  WalkPostResponseDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct PostDataDTO: Codable {
+    let posts: [PostDTO]
+}
+
+struct PostDTO: Codable {
+    let postId: Int
+    let createdAt: String
+    let isLike: Bool
+    let title: String
+    let routeId: Int
+    let representativeImageUrl: String
+    let writer: WriterDTO
+    let descriptionTags: [String]
+}
+
+struct WriterDTO: Codable {
+    let userId: Int
+    let petName: String
+    let petProfileImageUrl: String
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/Model/MapAndListTab.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/Model/MapAndListTab.swift
@@ -1,0 +1,11 @@
+//
+//  MapAndListTab.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+enum MapAndListTab: String, CaseIterable {
+    case map = "지도"
+    case list = "리스트"
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/Model/WalkPost.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/Model/WalkPost.swift
@@ -1,0 +1,25 @@
+//
+//  WalkPost.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct WalkPost: Hashable {
+    let postId: Int
+    let createdAt: String
+    let isLike: Bool
+    let title: String
+    let routeId: Int
+    let representativeImageUrl: String
+    let writer: PostWriter
+    let descriptionTags: [String]
+}
+
+struct PostWriter: Hashable {
+    let userId: Int
+    let petName: String
+    let petProfileImageUrl: String
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -155,28 +155,29 @@ extension MapAndListView {
                 }
             }
             .padding(.horizontal, 16)
-            
-            // 여기부터 리스트
-            ScrollView(showsIndicators: false) {
-                Spacer().frame(height: 34)
-                VStack {
-                    ForEach(mapAndListViewModel.posts, id: \.self) { post in
-                        ReviewCard(
-                            type: .others,
-                            walkRouteImg: post.representativeImageUrl,
-                            profileImg: post.writer.petProfileImageUrl,
-                            walkTitle: post.title,
-                            petName: post.writer.petName,
-                            postDate: post.createdAt,
-                            buttonPressed: post.isLike,
-                            data: post.descriptionTags
-                        )
+            if mapAndListViewModel.posts.isEmpty {
+                Color.pawkeyWhite2
+            } else {
+                ScrollView(showsIndicators: false) {
+                    Spacer().frame(height: 34)
+                    VStack {
+                        ForEach(mapAndListViewModel.posts, id: \.self) { post in
+                            ReviewCard(
+                                type: .others,
+                                walkRouteImg: post.representativeImageUrl,
+                                profileImg: post.writer.petProfileImageUrl,
+                                walkTitle: post.title,
+                                petName: post.writer.petName,
+                                postDate: post.createdAt,
+                                buttonPressed: post.isLike,
+                                data: post.descriptionTags
+                            )
+                        }
                     }
+                    .padding(.horizontal, 16)
                 }
-                .padding(.horizontal, 16)
+                .background(.pawkeyWhite2)
             }
-            .background(.pawkeyWhite2)
-            
         }
         .padding(.top, 10)
         .task {

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -12,28 +12,23 @@ import MapKit
 struct MapAndListView: View {
     @EnvironmentObject var coordinator: Coordinator<WalkScene>
     
-    @StateObject private var viewModel = WalkCourseViewModel()
+    @StateObject private var walkCourseViewModel = WalkCourseViewModel()
     @StateObject private var mapAndListViewModel = MapAndListViewModel()
-    
-    @State private var selectedMode: Int = 0
-    @State private var showWalkCourseView = false
-    @State private var userTrackingMode: MKUserTrackingMode = .none
-    @State private var shouldCenterOnUser: Bool = false
     
     @Namespace private var namespace
     
-    let tabs: [(title: String, mode: Int)] = [("지도", 0), ("리스트", 1)]
+    @State private var tab: MapAndListTab = .map
     
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 20) {
-                ForEach(tabs, id: \.mode) { tab in
+                ForEach(MapAndListTab.allCases, id: \.self) { tab in
                     TabButton(
-                        title: tab.title,
-                        isSelected: selectedMode == tab.mode,
+                        title: tab.rawValue,
+                        isSelected: walkCourseViewModel.selectedMode == tab,
                         namespace: namespace
                     ) {
-                        selectedMode = tab.mode
+                        walkCourseViewModel.selectedMode = tab
                     }
                     .fixedSize(horizontal: true, vertical: false)
                 }
@@ -43,131 +38,149 @@ struct MapAndListView: View {
             .padding(.top, 8)
             .padding(.leading, 16)
             
-            if selectedMode == 0 {
-                ZStack(alignment: .topLeading) {
-                    WalkMap(region: $viewModel.region,
-                            pathCoordinates: $viewModel.pathCoordinates,
-                            shouldCenterOnUser: $shouldCenterOnUser,
-                            userTrackingMode: $userTrackingMode)
-                    .edgesIgnoringSafeArea(.bottom)
-                    .overlay(
-                        VStack {
-                            Spacer()
-                            
-                            ZStack {
-                                Button {
-                                    showWalkCourseView = true
-                                } label: {
-                                    Text("산책 기록 시작하기")
-                                        .font(.body_16_sb)
-                                        .foregroundColor(.pawkeyWhite1)
-                                }
-                                .padding(.vertical, 16)
-                                .padding(.horizontal, 20)
-                                .background(.green500)
-                                .cornerRadius(8)
-                                .shadow(radius: 2)
-                                
-                                HStack {
-                                    Spacer()
-                                    Button(action: {
-                                        viewModel.centerMapOnCurrentLocation()
-                                        shouldCenterOnUser = true
-                                    }) {
-                                        Image(.mapGps)
-                                    }
-                                    .padding(.trailing, 16)
-                                }
-                            }
-                            .padding(.bottom, 98)
-                        },
-                        alignment: .bottom
-                    )
-                    
-                    Text("서대문구 홍은동")
-                        .font(.body_16_sb)
-                        .foregroundColor(.green500)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 12)
-                        .background(.pawkeyWhite1)
-                        .cornerRadius(60)
-                        .padding(.top, 18)
-                        .padding(.leading, 16)
-                }
-            } else {
-                // TODO: 별도의 뷰로 분리할 필요가 있을듯함
-                VStack {
-                    HStack {
-                        Button {
-                            mapAndListViewModel.isShowSheet = true
-                        } label: {
-                            Circle()
-                                .frame(width: 36, height: 36)
-                                .foregroundStyle(.pawkeyWhite1)
-                                .overlay {
-                                    Circle()
-                                        .stroke(Color.gray100, lineWidth: 1)
-                                }
-                                .overlay(Image(.settingGray))
-                        }
-                        Spacer()
-                        if mapAndListViewModel.selectedOptions.isEmpty {
-                            HStack {
-                                FilterChip(title: "")
-                                Spacer()
-                            }
-                        } else {
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                HStack {
-                                    ForEach(mapAndListViewModel.selectedOptions, id: \.self.id) {
-                                        FilterChip(title: $0.title)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                    
-                    ScrollView(showsIndicators: false) {
-                        Spacer().frame(height: 34)
-                        VStack {
-                            ForEach(1...10, id: \.self) { _ in
-                                ReviewCard(
-                                    type: .others,
-                                    walkRouteImg: "walkRoute",
-                                    profileImg: "profile",
-                                    walkTitle: "제목을 입력해주세요",
-                                    petName: "반려견 이름",
-                                    postDate: "2025-07-11",
-                                    data: ["이륜차 거의 없음", "배변 쓰레기통", "쉼터", "편의점", "동반 카페", "아스팔트/벽돌", "시끌벅적"]
-                                )
-                            }
-                        }
-                        .padding(.horizontal, 16)
-                    }
-                    .background(.pawkeyWhite2)
-                }
-                .padding(.top, 10)
+            switch walkCourseViewModel.selectedMode {
+            case .map:
+                mapView
+            case .list:
+                courseListView
             }
         }
         .onAppear {
-            viewModel.requestPermission()
+            walkCourseViewModel.requestPermission()
         }
-        .fullScreenCover(isPresented: $showWalkCourseView) {
-            WalkCourseView(viewModel: viewModel, showWalkCourseView: $showWalkCourseView) { distance, elapsedTime, stepCount, snapshot in
+        .fullScreenCover(isPresented: $walkCourseViewModel.showWalkCourseView) {
+            WalkCourseView(viewModel: walkCourseViewModel, showWalkCourseView: $walkCourseViewModel.showWalkCourseView) { distance, elapsedTime, stepCount, snapshot in
                 coordinator.push(.walkCompletion(
                     distance: distance,
                     elapsedTime: elapsedTime,
                     stepCount: stepCount,
                     snapshot: snapshot
                 ))
-                viewModel.resetTrackingData()
+                walkCourseViewModel.resetTrackingData()
             }
         }
         .sheet(isPresented: $mapAndListViewModel.isShowSheet) {
             FilterBottomSheet(viewModel: mapAndListViewModel)
                 .presentationDragIndicator(.visible)
                 .presentationDetents([.fraction(0.9)])
+        }
+    }
+}
+
+extension MapAndListView {
+    private var mapView: some View {
+        Group {
+            ZStack(alignment: .topLeading) {
+                WalkMap(region: $walkCourseViewModel.region,
+                        pathCoordinates: $walkCourseViewModel.pathCoordinates,
+                        shouldCenterOnUser: $walkCourseViewModel.shouldCenterOnUser,
+                        userTrackingMode: $walkCourseViewModel.userTrackingMode)
+                .edgesIgnoringSafeArea(.bottom)
+                .overlay(
+                    VStack {
+                        Spacer()
+                        
+                        ZStack {
+                            Button {
+                                walkCourseViewModel.showWalkCourseView = true
+                            } label: {
+                                Text("산책 기록 시작하기")
+                                    .font(.body_16_sb)
+                                    .foregroundColor(.pawkeyWhite1)
+                            }
+                            .padding(.vertical, 16)
+                            .padding(.horizontal, 20)
+                            .background(.green500)
+                            .cornerRadius(8)
+                            .shadow(radius: 2)
+                            
+                            HStack {
+                                Spacer()
+                                Button(action: {
+                                    walkCourseViewModel.centerMapOnCurrentLocation()
+                                    walkCourseViewModel.shouldCenterOnUser = true
+                                }) {
+                                    Image(.mapGps)
+                                }
+                                .padding(.trailing, 16)
+                            }
+                        }
+                        .padding(.bottom, 98)
+                    },
+                    alignment: .bottom
+                )
+                
+                Text("서대문구 홍은동")
+                    .font(.body_16_sb)
+                    .foregroundColor(.green500)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 12)
+                    .background(.pawkeyWhite1)
+                    .cornerRadius(60)
+                    .padding(.top, 18)
+                    .padding(.leading, 16)
+            }
+        }
+    }
+    
+    private var courseListView: some View {
+        VStack {
+            HStack {
+                Button {
+                    mapAndListViewModel.isShowSheet = true
+                } label: {
+                    Circle()
+                        .frame(width: 36, height: 36)
+                        .foregroundStyle(.pawkeyWhite1)
+                        .overlay {
+                            Circle()
+                                .stroke(Color.gray100, lineWidth: 1)
+                        }
+                        .overlay(Image(.settingGray))
+                }
+                Spacer()
+                if mapAndListViewModel.selectedOptions.isEmpty {
+                    HStack {
+                        FilterChip(title: "")
+                        Spacer()
+                    }
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack {
+                            ForEach(mapAndListViewModel.selectedOptions, id: \.self.id) {
+                                FilterChip(title: $0.title)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            
+            // 여기부터 리스트
+            ScrollView(showsIndicators: false) {
+                Spacer().frame(height: 34)
+                VStack {
+                    ForEach(mapAndListViewModel.posts, id: \.self) { post in
+                        ReviewCard(
+                            type: .others,
+                            walkRouteImg: post.representativeImageUrl,
+                            profileImg: post.writer.petProfileImageUrl,
+                            walkTitle: post.title,
+                            petName: post.writer.petName,
+                            postDate: post.createdAt,
+                            buttonPressed: post.isLike,
+                            data: post.descriptionTags
+                        )
+                    }
+                }
+                .padding(.horizontal, 16)
+            }
+            .background(.pawkeyWhite2)
+            
+        }
+        .padding(.top, 10)
+        .task {
+            await mapAndListViewModel.fetchPosts()
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/ViewModel/MapAndListViewModel.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Moya
+
 final class MapAndListViewModel: ObservableObject {
     
     enum WalkRouteOption {
@@ -16,6 +18,8 @@ final class MapAndListViewModel: ObservableObject {
         case environment(index: Int)
         case mood(index: Int)
     }
+    
+    @Published var posts: [WalkPost] = []
     
     @Published var isShowSheet = false
     @Published var isExpandWalkingTime = false
@@ -112,5 +116,24 @@ final class MapAndListViewModel: ObservableObject {
         var newList = list
         newList[index].isSelected.toggle()
         return newList
+    }
+}
+
+
+extension MapAndListViewModel {
+    @MainActor
+    func fetchPosts() async {
+        let provider = MoyaProvider<WalkPostAPI>(plugins: [MoyaLoggingPlugin()])
+        
+        do {
+            let response: BaseDTO<PostDataDTO> = try await provider.async.request(.fetchPosts)
+            
+            guard let data = response.data else {
+                return
+            }
+            self.posts = data.posts.toEntity()
+        } catch {
+            print("에러 발생: \(error.localizedDescription)")
+        }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Register/ViewModel/ProfileSetUpViewModel.swift
@@ -180,7 +180,7 @@ extension ProfileSetUpViewModel {
         let provider = MoyaProvider<UserAPI>(plugins: [MoyaLoggingPlugin()])
         
         do {
-            let response: BaseDTO<PetTraitDTO> = try await provider.async.request(.updateUserProfile(userProfile))
+            let response: BaseDTO<PostDataDTO> = try await provider.async.request(.updateUserProfile(userProfile))
             
             guard let data = response.data else {
                 errorMessage = "에러 발생: 데이터를 찾을 수 없음"

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/WalkCourseViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/WalkCourseViewModel.swift
@@ -38,6 +38,10 @@ final class WalkCourseViewModel: ObservableObject {
     @Published var elapsedTime: String = "00:00"
     @Published var stepCount: Int = 0
     
+    @Published var selectedMode: MapAndListTab = .map
+    @Published var showWalkCourseView = false
+    @Published var userTrackingMode: MKUserTrackingMode = .none    
+    
     init(locationManager: LocationManager = .shared) {
         self.locationManager = locationManager
         


### PR DESCRIPTION
## 📟 연결된 이슈
closed #108 

## 👷 작업한 내용
- 산책 게시물 리스트 조회 API를 연동합니다.
- 관련 API, DTO 객체를 추가했습니다.

## ⚠️ 참고 사항
- ReviewCard는 단순히 데이터를 보여주는 역할인데 @State를 사용하는게 맞는걸까요? 기록했다가 ReviewCard 컴포넌트 다시 보겠습니다

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "https://github.com/user-attachments/assets/324a9325-92d3-43ea-92a9-62395053ced5" width ="200"> |