### PR TITLE
[Network] #107 게시물 상세 조회 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Global/Coordinator/HomeCoordinator/HomeScene.swift
+++ b/PAWKEY/PAWKEY/Global/Coordinator/HomeCoordinator/HomeScene.swift
@@ -24,8 +24,8 @@ enum HomeScene: AppScene {
         case .acvitiyAreaMap:
             let viewModel = ActivityAreaMapViewModel()
             ActivityAreaMapView(viewModel: viewModel)
-        case .sharedCourseDetail(_):
-            let viewModel = CourseDetailViewModel()
+        case let .sharedCourseDetail(id):
+            let viewModel = CourseDetailViewModel(postId: id)
             CourseDetailView(viewModel: viewModel)
         }
     }

--- a/PAWKEY/PAWKEY/Global/Coordinator/MyPageCoordinator/MyPageScene.swift
+++ b/PAWKEY/PAWKEY/Global/Coordinator/MyPageCoordinator/MyPageScene.swift
@@ -13,7 +13,7 @@ enum MyPageScene: AppScene {
     case petProfile
     case savedCourse
     case myCourse
-    case courseDetail
+    case courseDetail(postId: Int)
     
     @ViewBuilder
     func build() -> some View {
@@ -32,8 +32,8 @@ enum MyPageScene: AppScene {
         case .myCourse:
             let viewModel = MyCourseViewModel()
             MyCourseView(viewModel: viewModel)
-        case .courseDetail:
-            CourseDetailView(viewModel: CourseDetailViewModel())
+        case let .courseDetail(postId):
+            CourseDetailView(viewModel: CourseDetailViewModel(postId: postId))
         }
     }
 }

--- a/PAWKEY/PAWKEY/Global/Coordinator/WalkCoordinator/WalkScene.swift
+++ b/PAWKEY/PAWKEY/Global/Coordinator/WalkCoordinator/WalkScene.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 enum WalkScene: AppScene {
     case courseList
-    case courseDetail(CourseDetailViewModel)
+    case courseDetail(postId: Int)
     case walkCompletion(distance: Double, elapsedTime: String, stepCount: Int, snapshot: UIImage?)
     case archive(snapshot: UIImage?)
     case sharedWalkCompletion(distance: Double, elapsedTime: String, stepCount: Int, snapshot: UIImage?)
@@ -20,7 +20,8 @@ enum WalkScene: AppScene {
         switch self {
         case .courseList:
             MapAndListView()
-        case .courseDetail(let viewModel):
+        case .courseDetail(let postId):
+            let viewModel = CourseDetailViewModel(postId: postId)
             CourseDetailView(viewModel: viewModel)
         case .walkCompletion(let distance, let elapsedTime, let stepCount, let snapshot):
             let viewModel = WalkCompletionViewModel(

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
@@ -11,12 +11,15 @@ import Moya
 
 enum WalkPostAPI {
     case fetchPosts
+    case fetchPostDetail(postId: Int)
 }
 
 extension WalkPostAPI: BaseTargetType {
     var headerType: HeaderType {
         switch self {
         case .fetchPosts:
+            return .userHeader(userId: 2)
+        default:
             return .userHeader(userId: 2)
         }
     }
@@ -25,6 +28,8 @@ extension WalkPostAPI: BaseTargetType {
         switch self {
         case .fetchPosts:
             return "posts/filter"
+        case let .fetchPostDetail(postId):
+            return "posts/\(postId)"
         }
     }
     
@@ -32,6 +37,8 @@ extension WalkPostAPI: BaseTargetType {
         switch self {
         case .fetchPosts:
             return .post
+        case .fetchPostDetail(_):
+            return .get
         }
     }
     
@@ -49,6 +56,8 @@ extension WalkPostAPI: BaseTargetType {
                 ]
             )
             return .requestJSONEncodable(dummy)
+        case .fetchPostDetail(_):
+            return .requestPlain
         }
     }
 }

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDetailResponseDTO.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDetailResponseDTO.swift
@@ -1,0 +1,56 @@
+//
+//  WalkPostDetailResponseDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct PostResponseDTO: Codable {
+    let postId: Int
+    let routeId: Int
+    let title: String
+    let content: String
+    let isLike: Bool
+    let authorInfo: AuthorInfoDTO
+    let categoryTags: CategoryTagsDTO
+    let regionName: String
+    let createdAt: String
+    let routeMapImageUrl: String
+    let walkingImageUrls: [String]
+}
+
+struct AuthorInfoDTO: Codable {
+    let authorId: Int
+    let petId: Int
+    let petName: String
+    let petProfileImage: String
+}
+
+struct CategoryTagsDTO: Codable {
+    let categoryOptionSummary: [String]
+}
+
+extension PostResponseDTO {
+    func toEntity() -> Post {
+        return Post(
+            id: postId,
+            routeId: routeId,
+            title: title,
+            content: content,
+            isLiked: isLike,
+            author: Author(
+                id: authorInfo.authorId,
+                petId: authorInfo.petId,
+                petName: authorInfo.petName,
+                petProfileImage: authorInfo.petProfileImage
+            ),
+            tags: categoryTags.categoryOptionSummary,
+            region: regionName,
+            createdDate: createdAt.toFormattedDateString() ?? createdAt,
+            routeImageUrl: routeMapImageUrl,
+            walkingImageUrls: walkingImageUrls
+        )
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MapAndList/View/MapAndListView.swift
@@ -175,6 +175,9 @@ extension MapAndListView {
                                 buttonPressed: post.isLike,
                                 data: post.descriptionTags
                             )
+                            .onTapGesture {
+                                coordinator.push(.courseDetail(postId: post.postId))
+                            }
                         }
                     }
                     .padding(.horizontal, 16)

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/MyCourseView.swift
@@ -43,7 +43,7 @@ struct MyCourseView: View {
                             data: viewModel.tagList
                         )
                         .onTapGesture {
-                            coordinator.push(.courseDetail)
+//                            coordinator.push(.courseDetail(postId: review.id))
                             mainTabViewModel.isHidden = true
                         }
                     }

--- a/PAWKEY/PAWKEY/Presentation/MyPage/View/SavedCourseView.swift
+++ b/PAWKEY/PAWKEY/Presentation/MyPage/View/SavedCourseView.swift
@@ -35,7 +35,7 @@ struct SavedCourseView: View {
                             data: course.tags
                         )
                         .onTapGesture {
-                            coordinator.push(.courseDetail)
+                            coordinator.push(.courseDetail(postId: course.id))
                             mainTabViewModel.isHidden = true
                         }
                     }

--- a/PAWKEY/PAWKEY/Presentation/Walk/Model/Post.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/Model/Post.swift
@@ -1,0 +1,29 @@
+//
+//  Post.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/16/25.
+//
+
+import Foundation
+
+struct Post {
+    let id: Int
+    let routeId: Int
+    let title: String
+    let content: String
+    let isLiked: Bool
+    let author: Author
+    let tags: [String]
+    let region: String
+    let createdDate: String
+    let routeImageUrl: String
+    let walkingImageUrls: [String]
+}
+
+struct Author {
+    let id: Int
+    let petId: Int
+    let petName: String
+    let petProfileImage: String
+}

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/ArchiveView.swift
@@ -174,16 +174,16 @@ struct ArchiveView: View {
         Task {
             await viewModel.uploadCourse(isPublic: !isPrivate)
 
-            let courseDetailVM = CourseDetailViewModel()
+//            let courseDetailVM = CourseDetailViewModel(postId: 0)
             var imagesToSend = viewModel.selectedImages
             
             if let snapshot = viewModel.snapshot {
                 imagesToSend.insert(snapshot, at: 0)
             }
             
-            courseDetailVM.images = imagesToSend
-            courseDetailVM.isPrivate = isPrivate
-            coordinator.push(.courseDetail(courseDetailVM))
+//            courseDetailVM.images = imagesToSend
+//            courseDetailVM.isPrivate = isPrivate
+            coordinator.push(.courseDetail(postId: 0))
         }
     }
 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Kingfisher
+
 struct CourseDetailView: View {
     @StateObject private var sharedWalkCourseViewModel = SharedWalkCourseViewModel()
     
@@ -40,6 +42,9 @@ struct CourseDetailView: View {
                     .padding(.horizontal, 16)
                 divider
                 Spacer().frame(height: 116)
+            }
+            .task {
+                await viewModel.fetchCoruseDetail()
             }
         }
         .ignoresSafeArea(.all, edges: .bottom)
@@ -89,36 +94,30 @@ struct CourseDetailView: View {
                 sharedWalkCourseViewModel.resetTrackingData()
             }
         }
+        .task {
+            await viewModel.fetchCoruseDetail()
+        }
     }
 }
 
 extension CourseDetailView {
     private var walkCourseImageView: some View {
-        Group {
-            if let snapshot = viewModel.images.first {
-                Image(uiImage: snapshot)
-                    .resizable()
-                //                    .scaledToFit()
-                    .frame(height: 250)
-                    .frame(maxWidth: .infinity)
-                    .clipped()
-            } else {
-                Rectangle()
-                    .fill(Color.pawkeyWhite2)
-                    .frame(height: 250)
-                    .frame(maxWidth: .infinity)
-            }
-        }
+            KFImage(URL(string: viewModel.post?.routeImageUrl ?? ""))
+                .resizable()
+                .frame(minHeight: 250, maxHeight: 250)
+                .frame(maxWidth: .infinity)
+                .aspectRatio(contentMode: .fit)
+                .clipped()
     }
     
     private var titleView: some View {
         VStack(spacing: 0) {
             HStack(spacing: 10) {
-                Text("제목 제목 제목")
+                Text(viewModel.post?.title ?? "")
                     .font(.head_20_sb)
                     .foregroundColor(.pawkeyBlack)
                 Spacer()
-                if viewModel.isPrivate {
+                if (viewModel.post?.isLiked ?? false) {
                     Image(.heartIconFill)
                 } else {
                     Image(.heartIconGray)
@@ -129,11 +128,13 @@ extension CourseDetailView {
     
     private var dogProfileView: some View {
         HStack(spacing: 10) {
-            Circle()
-                .fill(Color.green)
-                .frame(width: 43, height: 43)
-            
-            Text("강아지 이름")
+            KFImage(URL(string: viewModel.post?.author.petProfileImage ?? ""))
+                .resizable()
+                .frame(maxWidth: 43, maxHeight: 43)
+                .aspectRatio(contentMode: .fit)
+                .clipShape(Circle())
+                            
+            Text(viewModel.post?.author.petName ?? "")
                 .font(.body_16_sb)
                 .foregroundColor(.pawkeyBlack)
         }
@@ -161,10 +162,7 @@ extension CourseDetailView {
                 .padding(.bottom, 12)
             }
             
-            Text("""
-                 후기 글 본문 후기 글 본문 후기 글 본문ㅇ
-                 후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ후기 글 본문 후기 글 본문 후기 글 본문ㅇ
-                """)
+            Text(viewModel.post?.content ?? "")
             .font(.body_14_r)
             .foregroundStyle(.pawkeyBlack)
             .padding(.bottom, 12)
@@ -209,15 +207,17 @@ extension CourseDetailView {
     
     private var locationDateInfoView: some View {
         VStack(alignment: .leading) {
-            TimePlaceCell(type: .place("강남구 역삼동"))
+            TimePlaceCell(type: .place(viewModel.post?.region ?? ""))
                 .padding(.bottom, 4)
             
-            TimePlaceCell(type: .time("2025.07.08(화) | 오후 11:28"))
+            TimePlaceCell(type: .time(viewModel.post?.createdDate ?? ""))
                 .padding(.bottom, 12)
-            
-            Chip(title: "옵션")
-                .padding(.top, 10)
-                .padding(.bottom, 12)
+
+            FlexibleGrid(availableWidth: UIScreen.main.bounds.width - 32,
+                         data: viewModel.post?.tags ?? [],
+                         spacing: 8, alignment: .leading) {
+                            Chip(title: $0)
+            }
         }
     }
     

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Moya
+
 class CourseDetailViewModel: ObservableObject, Hashable {
     static func == (lhs: CourseDetailViewModel, rhs: CourseDetailViewModel) -> Bool {
         lhs.id == rhs.id
@@ -16,6 +18,7 @@ class CourseDetailViewModel: ObservableObject, Hashable {
         hasher.combine(id)
     }
     
+    let postId: Int
     let id = UUID()
     
     @Published var images: [UIImage] = []
@@ -24,4 +27,26 @@ class CourseDetailViewModel: ObservableObject, Hashable {
     @Published var isShowPhotoPreview = false
     @Published var isShowContextMenu = false
     @Published var isShowSharedWalkCourseView = false
+    
+    @Published var post: Post?
+    
+    init(postId: Int) {
+        self.postId = postId
+    }
+    
+    @MainActor
+    func fetchCoruseDetail() async {
+        let provider = MoyaProvider<WalkPostAPI>(plugins: [MoyaLoggingPlugin()])
+        
+        do {
+            let response: BaseDTO<PostResponseDTO> = try await provider.async.request(.fetchPostDetail(postId: postId))
+            
+            guard let data = response.data else {
+                return
+            }
+            self.post = data.toEntity()
+        } catch {
+            print("에러 발생: \(error.localizedDescription)")
+        }
+    }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #107 

## 👷 작업한 내용
- 게시물 상세 조회 API 를 연동합니다.
- 관련 DTO 객체 추가
- CourseDetail ViewModel 에서 postId를 받도록 수정


## ⚠️ 참고 사항
- 화면에 데이터가 잘 나오는것을 확인했으나 전체적으로 플로우 점검이 필요해 보입니다

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "https://github.com/user-attachments/assets/dbb5fbb4-922e-4f5a-bb71-519f71245bb4" width ="200"> |