### PR TITLE
[Network] #106 산책 후기 조회 API 연동

### DIFF
--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostAPI.swift
@@ -12,6 +12,7 @@ import Moya
 enum WalkPostAPI {
     case fetchPosts(FilterRequest)
     case fetchPostDetail(postId: Int)
+    case fetchReviewsTop(routeId: Int)
 }
 
 extension WalkPostAPI: BaseTargetType {
@@ -30,6 +31,8 @@ extension WalkPostAPI: BaseTargetType {
             return "posts/filter"
         case let .fetchPostDetail(postId):
             return "posts/\(postId)"
+        case let .fetchReviewsTop(routeId):
+            return "posts/\(routeId)/reviews/top"
         }
     }
     
@@ -39,6 +42,8 @@ extension WalkPostAPI: BaseTargetType {
             return .post
         case .fetchPostDetail(_):
             return .get
+        case .fetchReviewsTop(_):
+            return .get
         }
     }
     
@@ -47,6 +52,8 @@ extension WalkPostAPI: BaseTargetType {
         case let .fetchPosts(filterRequest):
             return .requestJSONEncodable(filterRequest)
         case .fetchPostDetail(_):
+            return .requestPlain
+        case .fetchReviewsTop(_):
             return .requestPlain
         }
     }

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostDataMapper.swift
@@ -33,3 +33,28 @@ extension WriterDTO {
         )
     }
 }
+
+// Review data mapping
+
+extension WalkPostReviewDTO {
+    func toEntity() -> WalkPostSummary {
+        return WalkPostSummary(
+            postId: postId,
+            totalReviewCount: totalReviewCount,
+            categoryTop3: categoryTop3.map { $0.toEntity() }
+        )
+    }
+}
+
+extension CategoryTopDTO {
+    func toEntity() -> CategoryTop {
+        return CategoryTop(
+            categoryId: categoryId,
+            categoryName: categoryName,
+            categoryOptionId: categoryOptionId,
+            optionText: optionText,
+            rank: rank,
+            percentage: percentage
+        )
+    }
+}

--- a/PAWKEY/PAWKEY/Network/WalkPost/WalkPostReviewDTO.swift
+++ b/PAWKEY/PAWKEY/Network/WalkPost/WalkPostReviewDTO.swift
@@ -1,0 +1,25 @@
+//
+//  WalkPostReviewDTO.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/17/25.
+//
+
+import Foundation
+
+struct WalkPostReviewDTO: Codable {
+    let postId: Int
+    let totalReviewCount: Int
+    let categoryTop3: [CategoryTopDTO]
+}
+
+struct CategoryTopDTO: Codable {
+    let categoryId: Int
+    let categoryName: String
+    let categoryOptionId: Int
+    let optionText: String
+    let rank: Int
+    let percentage: Int
+}
+
+

--- a/PAWKEY/PAWKEY/Presentation/Walk/Model/Review.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/Model/Review.swift
@@ -1,0 +1,25 @@
+//
+//  Review.swift
+//  PAWKEY
+//
+//  Created by 권석기 on 7/17/25.
+//
+
+struct WalkPostSummary:Hashable {
+    let postId: Int
+    let totalReviewCount: Int
+    let categoryTop3: [CategoryTop]
+}
+
+struct CategoryTop: Hashable {
+    let categoryId: Int
+    let categoryName: String
+    let categoryOptionId: Int
+    let optionText: String
+    let rank: Int
+    let percentage: Int
+    
+    var ratio: Double {
+        Double(percentage) / 100.0
+    }
+}

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
@@ -96,6 +96,7 @@ struct CourseDetailView: View {
         }
         .task {
             await viewModel.fetchCoruseDetail()
+            await viewModel.fetchReviewsTop()
         }
     }
 }
@@ -197,9 +198,9 @@ extension CourseDetailView {
             .padding(.vertical, 16)
             
             VStack {
-                ReviewRatingBar(title: "후기", rating: 0.6, rank: 1)
-                ReviewRatingBar(title: "후기", rating: 0.3, rank: 2)
-                ReviewRatingBar(title: "후기", rating: 0.2, rank: 3)
+                ForEach(viewModel.topReviews, id: \.self) {
+                    ReviewRatingBar(title: $0.optionText, rating: $0.ratio, rank: $0.rank)
+                }
             }
             .padding(.bottom, 24)
         }

--- a/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/View/CourseDetailView.swift
@@ -190,7 +190,7 @@ extension CourseDetailView {
                     .foregroundStyle(.pawkeyBlack)
                 HStack(spacing: 4) {
                     Image(.editIconGray)
-                    Text("후기 숫자")
+                    Text("\(viewModel.reviewCount)")
                         .font(.caption_12_m)
                         .foregroundStyle(.gray200)
                 }

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
@@ -18,6 +18,8 @@ class CourseDetailViewModel: ObservableObject, Hashable {
         hasher.combine(id)
     }
     
+    let provider = MoyaProvider<WalkPostAPI>(plugins: [MoyaLoggingPlugin()])
+    
     let postId: Int
     let id = UUID()
     
@@ -27,6 +29,7 @@ class CourseDetailViewModel: ObservableObject, Hashable {
     @Published var isShowPhotoPreview = false
     @Published var isShowContextMenu = false
     @Published var isShowSharedWalkCourseView = false
+    @Published var topReviews: [CategoryTop] = []
     
     @Published var post: Post?
     
@@ -36,7 +39,7 @@ class CourseDetailViewModel: ObservableObject, Hashable {
     
     @MainActor
     func fetchCoruseDetail() async {
-        let provider = MoyaProvider<WalkPostAPI>(plugins: [MoyaLoggingPlugin()])
+       
         
         do {
             let response: BaseDTO<PostResponseDTO> = try await provider.async.request(.fetchPostDetail(postId: postId))
@@ -45,6 +48,21 @@ class CourseDetailViewModel: ObservableObject, Hashable {
                 return
             }
             self.post = data.toEntity()
+        } catch {
+            print("에러 발생: \(error.localizedDescription)")
+        }
+    }
+    
+    @MainActor
+    func fetchReviewsTop() async {
+        guard let routeId = post?.routeId else { return }
+        do {
+            let response: BaseDTO<WalkPostReviewDTO> = try await provider.async.request(.fetchReviewsTop(routeId: routeId))
+            
+            guard let data = response.data else {
+                return
+            }
+            topReviews = data.toEntity().categoryTop3
         } catch {
             print("에러 발생: \(error.localizedDescription)")
         }

--- a/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
+++ b/PAWKEY/PAWKEY/Presentation/Walk/ViewModel/CourseDetailViewModel.swift
@@ -30,6 +30,7 @@ class CourseDetailViewModel: ObservableObject, Hashable {
     @Published var isShowContextMenu = false
     @Published var isShowSharedWalkCourseView = false
     @Published var topReviews: [CategoryTop] = []
+    @Published var reviewCount: Int = 0
     
     @Published var post: Post?
     
@@ -39,8 +40,6 @@ class CourseDetailViewModel: ObservableObject, Hashable {
     
     @MainActor
     func fetchCoruseDetail() async {
-       
-        
         do {
             let response: BaseDTO<PostResponseDTO> = try await provider.async.request(.fetchPostDetail(postId: postId))
             
@@ -63,6 +62,10 @@ class CourseDetailViewModel: ObservableObject, Hashable {
                 return
             }
             topReviews = data.toEntity().categoryTop3
+            
+            self.reviewCount = data.toEntity().totalReviewCount
+            
+            print(reviewCount)
         } catch {
             print("에러 발생: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #106 

## 👷 작업한 내용
- 산책 후기 조회 API 연동
- 관련 모델 DTO 객체 추가
- CourseDetailView에 데이터 바인딩

## ⚠️ 참고 사항
- 참고 사항

## 📸 스크린샷
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "" width ="200"> | <img src = "" width ="200"> | <img src = "https://github.com/user-attachments/assets/250c950a-56e0-4867-8d71-7e25112fc7d7" width ="200"> |